### PR TITLE
fix #83 rss3 api update some UMS

### DIFF
--- a/src/upstream/rss3/mod.rs
+++ b/src/upstream/rss3/mod.rs
@@ -186,6 +186,12 @@ async fn save_item(p: ResultItem) -> Result<TargetProcessedList, Error> {
     let found = p
         .actions
         .iter()
+        // collectible (transfer, mint, burn) share the same UMS, but approve/revoke not.
+        .filter(|a| {
+            (a.tag_type == "transfer" && p.tag_type == "transfer")
+                || (a.tag_type == "mint" && p.tag_type == "mint")
+                || (a.tag_type == "burn" && p.tag_type == "burn")
+        })
         .find(|a| (p.tag == "collectible" && a.tag == "collectible"));
     if found.is_none() {
         return Ok(vec![]);

--- a/src/upstream/rss3/mod.rs
+++ b/src/upstream/rss3/mod.rs
@@ -187,10 +187,10 @@ async fn save_item(p: ResultItem) -> Result<TargetProcessedList, Error> {
         .actions
         .iter()
         // collectible (transfer, mint, burn) share the same UMS, but approve/revoke not.
+        // we need to record is the `hold` relation, so burn is excluded
         .filter(|a| {
             (a.tag_type == "transfer" && p.tag_type == "transfer")
                 || (a.tag_type == "mint" && p.tag_type == "mint")
-                || (a.tag_type == "burn" && p.tag_type == "burn")
         })
         .find(|a| (p.tag == "collectible" && a.tag == "collectible"));
     if found.is_none() {


### PR DESCRIPTION
Rss3 api updates some UMS: unified metadata schemas.
`action.type == "collectible"` and `action.tag == (transfer, mint, burn)` share the same UMS
but `action.tag == (approve, revoke)` are not.