### PR TITLE
Upstream/dotbit

### DIFF
--- a/src/graph/edge/resolve.rs
+++ b/src/graph/edge/resolve.rs
@@ -51,9 +51,9 @@ pub enum DomainNameSystem {
     Lens,
 
     /// https://unstoppabledomains.com/
-    #[strum(serialize = "UnstoppableDomains")]
-    #[serde(rename = "UnstoppableDomains")]
-    #[graphql(name = "UnstoppableDomains")]
+    #[strum(serialize = "unstoppabledomains")]
+    #[serde(rename = "unstoppabledomains")]
+    #[graphql(name = "unstoppabledomains")]
     UnstoppableDomains,
 
     #[default]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 pub use vertex::Vertex;
 
 use self::{
-    edge::{Hold, HoldRecord, Proof},
+    edge::{Hold, HoldRecord, Proof, Resolve},
     vertex::{Contract, ContractRecord, Identity, IdentityRecord},
 };
 
@@ -94,6 +94,18 @@ pub async fn create_identity_to_identity_hold_record(
     let from_record = from.create_or_update(db).await?;
     let to_record = to.create_or_update(db).await?;
     hold.connect(db, &from_record, &to_record).await?;
+    Ok(())
+}
+
+pub async fn create_domain_resolve_record(
+    db: &DatabaseConnection,
+    from: &Identity,
+    to: &Identity,
+    resolve: &Resolve,
+) -> Result<(), Error> {
+    let from_record = from.create_or_update(db).await?;
+    let to_record = to.create_or_update(db).await?;
+    resolve.connect(db, &from_record, &to_record).await?;
     Ok(())
 }
 

--- a/src/upstream/types/data_source.rs
+++ b/src/upstream/types/data_source.rs
@@ -75,9 +75,9 @@ pub enum DataSource {
     Dotbit,
 
     /// UnstoppableDomains
-    #[strum(serialize = "UnstoppableDomains")]
-    #[serde(rename = "UnstoppableDomains")]
-    #[graphql(name = "UnstoppableDomains")]
+    #[strum(serialize = "unstoppabledomains")]
+    #[serde(rename = "unstoppabledomains")]
+    #[graphql(name = "unstoppabledomains")]
     UnstoppableDomains,
 
     /// .lens

--- a/src/upstream/types/platform.rs
+++ b/src/upstream/types/platform.rs
@@ -80,9 +80,9 @@ pub enum Platform {
     Minds,
 
     /// UnstoppableDomains
-    #[strum(serialize = "unstoppable_domains")]
-    #[serde(rename = "unstoppable_domains")]
-    #[graphql(name = "unstoppable_domains")]
+    #[strum(serialize = "unstoppabledomains")]
+    #[serde(rename = "unstoppabledomains")]
+    #[graphql(name = "unstoppabledomains")]
     UnstoppableDomains,
 
     /// Unknown


### PR DESCRIPTION
1. unify `unstoppabledomains` as string value
2. distinguish 'regular' resolve & 'reverse' resolve record in GraphDB
3. fix `Platform::Dotbit` resolve record