### PR TITLE
fix ENS Domain `resolved` & `owner` query method

### DIFF
--- a/src/graph/edge/resolve.rs
+++ b/src/graph/edge/resolve.rs
@@ -153,8 +153,11 @@ impl Resolve {
 
         let aql_str = r###"
             FOR r IN @@resolves
-                FILTER r.system == @system AND r.name == @name
-                LET resolved = FIRST(FOR c IN @@identities FILTER c._id == r._to RETURN c)
+                FILTER r.system == @system AND 
+                r.name == @name AND
+                CONTAINS(r._from, "Identities") AND
+                CONTAINS(r._to, "Contracts")
+                LET resolved = FIRST(FOR c IN @@identities FILTER c._id == r._from RETURN c)
             FOR h IN @@holds
                 FILTER h.id == @name
                 LET owner = FIRST(FOR c IN @@identities FILTER c._id == h._from RETURN c)

--- a/src/upstream/unstoppable/mod.rs
+++ b/src/upstream/unstoppable/mod.rs
@@ -16,7 +16,7 @@ use futures::future::join_all;
 use http::uri::InvalidUri;
 use hyper::{Body, Method};
 use serde::Deserialize;
-use tracing::error;
+use tracing::{error, warn};
 use uuid::Uuid;
 
 use super::types::target;
@@ -93,6 +93,8 @@ pub struct Records {
     #[serde(rename = "crypto.ETH.address")]
     pub eth_address: Option<String>,
 }
+
+const UNKNOWN_OWNER: &str = "0x0000000000000000000000000000000000000000";
 
 pub struct UnstoppableDomains {}
 #[async_trait]
@@ -365,6 +367,11 @@ async fn fetch_account_by_domain(
     let result = fetch_owner(identity).await?;
     if result.meta.owner.is_none() {
         return Ok(vec![]);
+    }
+
+    if result.meta.owner.clone().unwrap().to_lowercase() == UNKNOWN_OWNER {
+        warn!("UnstoppableDomains owner is zero address");
+        return Err(Error::NoResult);
     }
 
     let eth_identity: Identity = Identity {


### PR DESCRIPTION
fix ENS Domain resolved & owner query method 
Although our service ENS reverse query needs to strictly require that "owner and reverse resolution must set to be the same 'soul'"
But the domain query method still needs to display this kind of relation

So I push this fix issue