### PR TITLE
Feature/social graph

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -3,50 +3,51 @@ name: Build container
 on:
   push:
     branches:
-    - main
-    - develop
-    # DEBUG
-    - graphdb/tigergraph
+      - main
+      - develop
+      # DEBUG
+      - graphdb/tigergraph
+      - feature/social-data
 
 jobs:
   build-image:
-    if: (github.ref_name == 'main' || github.ref_name == 'develop' || github.ref_name == 'graphdb/tigergraph') && github.repository == 'nextdotid/relation_server'
+    if: (github.ref_name == 'main' || github.ref_name == 'develop' || github.ref_name == 'feature/social-data') && github.repository == 'nextdotid/relation_server'
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Log in to Container registry
-      uses: docker/login-action@v2
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Setup Docker BuildX
-      uses: docker/setup-buildx-action@v2
-    - name: Cache Docker layers
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-docker-build-${{ hashFiles('**/Cargo.lock') }}
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-    - name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        context: '.'
-        push: true
-        file: Dockerfile
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Log in to Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Docker BuildX
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-build-${{ hashFiles('**/Cargo.lock') }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: "."
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -7,11 +7,11 @@ on:
       - develop
       # DEBUG
       - graphdb/tigergraph
-      - feature/social-data
+      - feature/social-graph
 
 jobs:
   build-image:
-    if: (github.ref_name == 'main' || github.ref_name == 'develop' || github.ref_name == 'feature/social-data') && github.repository == 'nextdotid/relation_server'
+    if: (github.ref_name == 'main' || github.ref_name == 'develop' || github.ref_name == 'feature/social-graph') && github.repository == 'nextdotid/relation_server'
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io

--- a/src/config/tdb/migrations/LoadingJob_SocialGraph.gsql
+++ b/src/config/tdb/migrations/LoadingJob_SocialGraph.gsql
@@ -662,11 +662,11 @@ CREATE OR REPLACE QUERY query_identity_graph_by_ids(SET<STRING> ids) FOR GRAPH S
 
 
 CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<STRING> sources, INT numPerPage = 200, INT pageNum = 0) FOR GRAPH SocialGraph {
-  TYPEDEF TUPLE< VERTEX source_v, VERTEX target_v, STRING original_from, STRINg original_to, STRING data_source, STRING edge_type , STRING tag > Relation;
+  TYPEDEF TUPLE< VERTEX source_v, VERTEX target_v, STRING original_from, STRINg original_to, STRING data_source, STRING edge_type , STRING tag, DATETIME updated_at > Relation;
 
-  TYPEDEF TUPLE< STRING chain, STRING address > Address;
-  SetAccum<Address> @owner_address;
-  SetAccum<Address> @resolve_address;
+  // TYPEDEF TUPLE< STRING chain, STRING address > Address;
+  // SetAccum<Address> @owner_address;
+  // SetAccum<Address> @resolve_address;
 
   OrAccum @visited = FALSE;
   SumAccum<INT> @degree;
@@ -681,6 +681,9 @@ CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<S
   SetAccum<VERTEX> @@original_vset; // collect for original Identities vertex
   
   seed (IdentitiesGraph) = {g};
+  seed = SELECT s FROM seed:s
+     ACCUM s.@visited += true,
+           s.@degree = s.outdegree("Follow");
   @@vertices += g;
   
   T = SELECT hv FROM seed-((Follow>|<Follow):e)-IdentitiesGraph:hv
@@ -710,8 +713,8 @@ CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<S
            PER (s1, s2, e1, e2, tgt)
            ACCUM
                 IF e1.source == e2.source THEN
-                  @@edges += Relation(s1, tgt, e1.original_from, e1.original_to, e1.source, "following", "mutual_follow"),
-                  @@edges += Relation(tgt, s2, e2.original_from, e2.original_to, e2.source, "follower", "mutual_follow"),
+                  @@edges += Relation(s1, tgt, e1.original_from, e1.original_to, e1.source, "following", "mutual_follow", e1.updated_at),
+                  @@edges += Relation(tgt, s2, e2.original_from, e2.original_to, e2.source, "follower", "mutual_follow", e2.updated_at),
                   @@original_vid += e1.original_from,
                   @@original_vid += e1.original_to,
                   tgt.@range += 3,
@@ -735,7 +738,7 @@ CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<S
     tmp_2 = SELECT tgt FROM seed:s1-((Follow>):e)-following:tgt
                  PER (s1, e, tgt)
                  ACCUM
-                       @@edges += Relation(s1, tgt, e.original_from, e.original_to, e.source, "following", ""),
+                       @@edges += Relation(s1, tgt, e.original_from, e.original_to, e.source, "following", "", e.updated_at),
                        @@original_vid += e.original_from,
                        @@original_vid += e.original_to,
                        tgt.@range += 2,
@@ -759,7 +762,7 @@ CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<S
     tmp_3 = SELECT tgt FROM seed:s1-((<Follow):e)-follower:tgt
                  PER (s1, e, tgt)
                  ACCUM
-                       @@edges += Relation(s1, tgt, e.original_from, e.original_to, e.source, "follower", ""),
+                       @@edges += Relation(s1, tgt, e.original_from, e.original_to, e.source, "follower", "", e.updated_at),
                        @@original_vid += e.original_from,
                        @@original_vid += e.original_to,
                        tgt.@range += 1,
@@ -773,10 +776,10 @@ CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<S
   original_vertices = { @@original_vset };
   vertices = { @@vertices };
 
-  tmp = SELECT domain FROM original_vertices:domain-((<Hold_Identity):e)-Identities:owner
-            ACCUM domain.@owner_address += Address(owner.platform, owner.identity);
-  tmp2 = SELECT domain FROM original_vertices:domain-((Resolve>):e)-Identities:tgt
-          ACCUM domain.@resolve_address += Address(tgt.platform, tgt.identity);
+  // tmp = SELECT domain FROM original_vertices:domain-((<Hold_Identity):e)-Identities:owner
+  //           ACCUM domain.@owner_address += Address(owner.platform, owner.identity);
+  // tmp2 = SELECT domain FROM original_vertices:domain-((Resolve>):e)-Identities:tgt
+  //         ACCUM domain.@resolve_address += Address(tgt.platform, tgt.identity);
 
   PRINT @@all_count as all_count, @@edges as edges, vertices, original_vertices;
 }

--- a/src/config/tdb/migrations/LoadingJob_SocialGraph.gsql
+++ b/src/config/tdb/migrations/LoadingJob_SocialGraph.gsql
@@ -614,6 +614,174 @@ CREATE OR REPLACE QUERY find_identity_graph(STRING p, INT reverse_flag=0) FOR GR
   END;
 }
 
+CREATE OR REPLACE QUERY query_identity_graph_by_ids(SET<STRING> ids) FOR GRAPH SocialGraph {
+  TYPEDEF TUPLE< VERTEX source_v, VERTEX target_v, STRING data_source, STRING edge_type > IdentityConnection;
+  TYPEDEF TUPLE< STRING chain, STRING address > Address;
+
+  SetAccum<Address> @owner_address;
+  SetAccum<Address> @resolve_address;
+
+  SetAccum<IdentityConnection> @@edges;
+  SetAccum<VERTEX> @@hyper_vset;
+  @@hyper_vset = to_vertex_set(ids, "IdentitiesGraph");
+  hyper_vertices (IdentitiesGraph) = {@@hyper_vset};
+
+  FOREACH hv IN @@hyper_vset DO
+    @@edges.clear();
+    hyper_v = {hv};
+    vset = SELECT v FROM Identities:v-((PartOfIdentitiesGraph>):e)-hyper_v LIMIT 500;
+
+    tmp1 = SELECT v1 FROM vset:v1-((Proof_Forward>|Proof_Backward>):e1)-vset:v2
+            ACCUM @@edges += IdentityConnection(v1, v2, e1.source, "Proof");
+    tmp2 = SELECT v1 FROM vset:v1-((<Proof_Forward|<Proof_Backward):e2)-vset:v2
+          ACCUM @@edges += IdentityConnection(v2, v1, e2.source, "Proof");
+    tmp4 = SELECT v1  FROM vset:v1-((Hold_Identity>):e1)-vset:i-((Resolve>):e2)-vset:v2
+          WHERE i.platform != "ENS" AND i.platform != "sns"
+          ACCUM @@edges += IdentityConnection(v1, i, e1.source, "Hold"),
+                i.@owner_address += Address(v1.platform, v1.identity), 
+                i.@resolve_address += Address(v2.platform, v2.identity);
+    tmp5 = SELECT v1 FROM vset:v1-((Hold_Identity>):e1)-vset:v2
+          WHERE v2.platform != "ENS" AND v2.platform != "sns"
+          ACCUM @@edges += IdentityConnection(v1, v2, e1.source, "Hold"),
+                v2.@owner_address += Address(v1.platform, v1.identity);
+    tmp3 = SELECT v1 FROM vset:v1-((Resolve>):r)-vset:v2
+          WHERE v1.platform == "ENS" OR v1.platform == "sns"
+          ACCUM
+            @@edges += IdentityConnection(v1, v2, r.source, "Resolve"),
+            v1.@resolve_address += Address(v2.platform, v2.identity);
+    tmp3_1 = SELECT v1 FROM vset:v1-((Hold_Identity>):e1)-vset:v2
+          WHERE v2.platform == "ENS" OR v2.platform == "sns"
+          ACCUM v2.@owner_address += Address(v1.platform, v1.identity);
+
+    tmp6 = SELECT v1 FROM vset:v1-((Reverse_Resolve>):e1)-vset:v2
+          ACCUM @@edges += IdentityConnection(v1, v2, e1.source, "Reverse_Resolve");
+
+    PRINT hv as graph_id, vset as vertices, @@edges as edges;
+  END;
+}
+
+
+CREATE OR REPLACE QUERY social_follows(VERTEX<IdentitiesGraph> g, INT hop, SET<STRING> sources, INT numPerPage = 200, INT pageNum = 0) FOR GRAPH SocialGraph {
+  TYPEDEF TUPLE< VERTEX source_v, VERTEX target_v, STRING original_from, STRINg original_to, STRING data_source, STRING edge_type , STRING tag > Relation;
+
+  TYPEDEF TUPLE< STRING chain, STRING address > Address;
+  SetAccum<Address> @owner_address;
+  SetAccum<Address> @resolve_address;
+
+  OrAccum @visited = FALSE;
+  SumAccum<INT> @degree;
+  SumAccum<INT> @range;
+  SumAccum<INT> @@all_count;
+
+  SetAccum<Relation> @@edges;
+  SetAccum<EDGE<Follow>> @@follow_edges;
+  SetAccum<VERTEX> @@vertices;
+
+  SetAccum<STRING> @@original_vid;
+  SetAccum<VERTEX> @@original_vset; // collect for original Identities vertex
+  
+  seed (IdentitiesGraph) = {g};
+  @@vertices += g;
+  
+  T = SELECT hv FROM seed-((Follow>|<Follow):e)-IdentitiesGraph:hv
+      PER (hv)
+      ACCUM @@all_count += 1;
+
+  WHILE(seed.size()>0) LIMIT hop DO
+    SetAccum<VERTEX> @@pool;
+    // mutual follow
+    INT size_0 = @@vertices.size();
+    INT index_start = numPerPage * pageNum;
+    INT index_end = numPerPage;
+    IF index_end - size_0 <= 0 THEN
+      BREAK;
+    END;
+
+    mutual_follow = SELECT hv FROM seed:s1-((Follow>):e1)-IdentitiesGraph:hv-((Follow>):e2)-seed:s2
+                 WHERE hv.@visited == FALSE AND s1 == s2
+                 POST-ACCUM
+                        hv.@visited = TRUE, 
+                        hv.@degree = hv.outdegree("Follow")
+                 ORDER BY hv.@degree DESC
+                 LIMIT index_start, index_end - size_0;
+
+    tmp_1 = SELECT tgt FROM seed:s1-((Follow>):e1)-mutual_follow:tgt-((Follow>):e2)-seed:s2
+           WHERE s1 == s2 AND s1 != tgt
+           PER (s1, s2, e1, e2, tgt)
+           ACCUM
+                IF e1.source == e2.source THEN
+                  @@edges += Relation(s1, tgt, e1.original_from, e1.original_to, e1.source, "following", "mutual_follow"),
+                  @@edges += Relation(tgt, s2, e2.original_from, e2.original_to, e2.source, "follower", "mutual_follow"),
+                  @@original_vid += e1.original_from,
+                  @@original_vid += e1.original_to,
+                  tgt.@range += 3,
+                  @@pool += tgt,
+                  @@vertices += tgt
+                END;
+
+    INT size_1 = @@vertices.size();
+    IF index_end - size_1 <= 0 THEN
+      BREAK;
+    END;
+
+    following = SELECT hv FROM seed:s1-((Follow>):e)-IdentitiesGraph:hv
+                 WHERE hv.@visited == FALSE
+                 POST-ACCUM
+                       hv.@visited = TRUE,
+                       hv.@degree = hv.outdegree("Follow")
+                 ORDER BY hv.@degree DESC
+                 LIMIT index_start, index_end - size_1;
+
+    tmp_2 = SELECT tgt FROM seed:s1-((Follow>):e)-following:tgt
+                 PER (s1, e, tgt)
+                 ACCUM
+                       @@edges += Relation(s1, tgt, e.original_from, e.original_to, e.source, "following", ""),
+                       @@original_vid += e.original_from,
+                       @@original_vid += e.original_to,
+                       tgt.@range += 2,
+                       @@pool += tgt,
+                       @@vertices += tgt;
+
+
+    INT size_2 = @@vertices.size();
+    IF index_end - size_2 <= 0 THEN
+      BREAK;
+    END;
+
+    follower = SELECT hv FROM seed:s1-((<Follow):e)-IdentitiesGraph:hv
+                 WHERE hv.@visited == FALSE
+                 POST-ACCUM
+                       hv.@visited = TRUE,
+                       hv.@degree = hv.outdegree("Follow")
+                 ORDER BY hv.@degree DESC
+                 LIMIT index_start, index_end - size_2;
+
+    tmp_3 = SELECT tgt FROM seed:s1-((<Follow):e)-follower:tgt
+                 PER (s1, e, tgt)
+                 ACCUM
+                       @@edges += Relation(s1, tgt, e.original_from, e.original_to, e.source, "follower", ""),
+                       @@original_vid += e.original_from,
+                       @@original_vid += e.original_to,
+                       tgt.@range += 1,
+                       @@pool += tgt,
+                       @@vertices += tgt;
+
+    seed (IdentitiesGraph) = {@@pool};
+  END;
+
+  @@original_vset = to_vertex_set(@@original_vid, "Identities");
+  original_vertices = { @@original_vset };
+  vertices = { @@vertices };
+
+  tmp = SELECT domain FROM original_vertices:domain-((<Hold_Identity):e)-Identities:owner
+            ACCUM domain.@owner_address += Address(owner.platform, owner.identity);
+  tmp2 = SELECT domain FROM original_vertices:domain-((Resolve>):e)-Identities:tgt
+          ACCUM domain.@resolve_address += Address(tgt.platform, tgt.identity);
+
+  PRINT @@all_count as all_count, @@edges as edges, vertices, original_vertices;
+}
+
+
 CREATE OR REPLACE QUERY neighbors(VERTEX<Identities> p, INT depth) FOR GRAPH SocialGraph { 
   SetAccum<EDGE> @@edges;
   SetAccum<VERTEX> @@vertices;

--- a/src/config/tdb/migrations/run_loading_jobs.gsql
+++ b/src/config/tdb/migrations/run_loading_jobs.gsql
@@ -92,3 +92,32 @@ CREATE LOADING JOB Load_DBExport FOR GRAPH IdentityGraph {
   LOAD "/home/tigergraph/shared_data/export_graphs/GlobalTypes/Resolve_Contract.csv" TO EDGE Resolve_Contract VALUES($"from", $"to", $"source", $"system", $"name", $"uuid", $"updated_at", $"fetcher") USING SEPARATOR="\t", HEADER="true", EOL="\n";
   LOAD "/home/tigergraph/shared_data/export_graphs/GlobalTypes/Reverse_Resolve_Contract.csv" TO EDGE Reverse_Resolve_Contract VALUES($"from", $"to", $"source", $"system", $"name", $"uuid", $"updated_at", $"fetcher") USING SEPARATOR="\t", HEADER="true", EOL="\n";
 }
+
+
+CREATE LOADING JOB Load_LensSocialFeed FOR GRAPH SocialGraph {
+  // ethereum identity and lens identity already have been loading in call `upsert_hyper_vertex()`
+  // from	to	source	uuid	id	updated_at	fetcher
+  LOAD "/home/tigergraph/shared_data/lens_v2_social_feeds/lens.hold.tsv"
+    TO EDGE Hold_Identity VALUES ($"from", $"to", $"source", REDUCE(ignore_if_exists($"uuid")), _, $"id", _, REDUCE(max($"updated_at")), $"fetcher", _) USING SEPARATOR = "\t", EOL = "\n", HEADER = "true";
+  // from	to	source	system	name	uuid	updated_at	fetcher
+  LOAD "/home/tigergraph/shared_data/lens_v2_social_feeds/lens.resolve.tsv"
+    TO EDGE Resolve VALUES ($"from", $"to", $"source", $"system", $"name", REDUCE(ignore_if_exists($"uuid")), REDUCE(max($"updated_at")), $"fetcher") USING SEPARATOR = "\t", EOL = "\n", HEADER = "true";
+  // from	to	source	system	name	uuid	updated_at	fetcher
+  LOAD "/home/tigergraph/shared_data/lens_v2_social_feeds/lens.reverse_resolve.tsv"
+    TO EDGE Reverse_Resolve VALUES ($"from", $"to", $"source", $"system", $"name", REDUCE(ignore_if_exists($"uuid")), REDUCE(max($"updated_at")), $"fetcher") USING SEPARATOR = "\t", EOL = "\n", HEADER = "true";
+  // from	to	original_from	original_to	source	updated_at
+  LOAD "/home/tigergraph/shared_data/lens_v2_social_feeds/lens.follow.tsv"
+    TO EDGE Follow VALUES ($"from", $"to", $"original_from", $"original_to", $"source", REDUCE(max($"updated_at"))) USING SEPARATOR = "\t", EOL = "\n", HEADER = "true";
+}
+
+RUN LOADING JOB Load_LensSocialFeed
+
+
+CREATE LOADING JOB Load_KeybaseSocialFeed FOR GRAPH SocialGraph {
+  LOAD "/home/tigergraph/shared_data/keybase_social_feeds/keybase.proof.tsv"
+    TO EDGE Proof_Forward VALUES ($"from", $"to", $"source", $"created_at", $"uuid", $"level", $"record_id", $"updated_at", $"fetcher") USING SEPARATOR = "\t", EOL = "\n", HEADER = "true";
+  LOAD "/home/tigergraph/shared_data/keybase_social_feeds/keybase.follow.tsv"
+    TO EDGE Follow VALUES ($"from", $"to", $"original_from", $"original_to", $"source", REDUCE(max($"updated_at"))) USING SEPARATOR = "\t", EOL = "\n", HEADER = "true";
+}
+
+RUN LOADING JOB Load_KeybaseSocialFeed

--- a/src/controller/tigergraphql/mod.rs
+++ b/src/controller/tigergraphql/mod.rs
@@ -5,8 +5,12 @@ mod identity_graph;
 mod proof;
 mod relation;
 mod resolve;
+mod social;
 
-use self::{hold::HoldQuery, identity::IdentityQuery, proof::ProofQuery, resolve::ResolveQuery};
+use self::{
+    hold::HoldQuery, identity::IdentityQuery, proof::ProofQuery, resolve::ResolveQuery,
+    social::RelationQuery,
+};
 use async_graphql::{MergedObject, Object};
 const API_VERSION: &str = "0.1";
 
@@ -18,6 +22,7 @@ pub struct Query(
     ResolveQuery,
     ProofQuery,
     HoldQuery,
+    RelationQuery,
 );
 
 #[derive(Default)]

--- a/src/controller/tigergraphql/social.rs
+++ b/src/controller/tigergraphql/social.rs
@@ -1,0 +1,109 @@
+use crate::{
+    error::Result,
+    tigergraph::{
+        edge::Relation,
+        vertex::{ExpandIdentityRecord, IdentityGraph},
+    },
+    upstream::{DataSource, Platform},
+    util::make_http_client,
+};
+
+use async_graphql::{Context, Object};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationResult {
+    identity_graph: IdentityGraph,
+}
+
+#[Object]
+impl Relation {
+    async fn edge_type(&self) -> String {
+        self.relation.edge_type.clone()
+    }
+    async fn tag(&self) -> Option<String> {
+        self.relation.tag.clone()
+    }
+    async fn data_source(&self) -> DataSource {
+        self.relation.data_source.clone()
+    }
+
+    async fn source(&self) -> String {
+        self.relation.from_id.clone()
+    }
+
+    async fn target(&self) -> String {
+        self.relation.to_id.clone()
+    }
+
+    async fn original_source(&self) -> &Option<ExpandIdentityRecord> {
+        &self.original_from
+    }
+
+    async fn original_target(&self) -> &Option<ExpandIdentityRecord> {
+        &self.original_to
+    }
+}
+
+#[Object]
+impl RelationResult {
+    async fn identity_graph(&self) -> &IdentityGraph {
+        &self.identity_graph
+    }
+
+    #[graphql(complexity = 1)]
+    async fn follow(
+        &self,
+        _ctx: &Context<'_>,
+        #[graphql(
+            desc = "`hop` relationships in a social network refers to the degrees of separation between entities.
+                1 if omitted. 1-Hop (Direct Friends), 2-Hop (Friends of Friends), 3-Hop (Friends of Friends of Friends)."
+        )]
+        hop: Option<u16>,
+        data_source: Option<Vec<DataSource>>,
+        #[graphql(
+            desc = "`limit` used to control the maximum number of records returned by query. It defaults to 100"
+        )]
+        limit: Option<u16>,
+        #[graphql(
+            desc = "`offset` determines the starting position from which the records are retrieved in query. It defaults to 0."
+        )]
+        offset: Option<u16>,
+    ) -> Result<Option<Vec<Relation>>> {
+        let client = make_http_client();
+        self.identity_graph
+            .follow(
+                &client,
+                hop.unwrap_or(1),
+                data_source,
+                limit.unwrap_or(200),
+                offset.unwrap_or(0),
+            )
+            .await
+    }
+}
+
+#[derive(Default)]
+pub struct RelationQuery;
+
+#[Object]
+impl RelationQuery {
+    async fn relation(
+        &self,
+        _ctx: &Context<'_>,
+        #[graphql(desc = "Platform to query")] platform: String,
+        #[graphql(desc = "Identity on target Platform")] identity: String,
+    ) -> Result<Option<RelationResult>> {
+        let client = make_http_client();
+        let platform: Platform = platform.parse()?;
+        match IdentityGraph::find_graph_by_platform_identity(&client, &platform, &identity, None)
+            .await?
+        {
+            None => {
+                // TODO: fetch_all
+                Ok(None)
+            }
+            Some(identity_graph) => Ok(Some(RelationResult { identity_graph })),
+        }
+    }
+}

--- a/src/tigergraph/edge/mod.rs
+++ b/src/tigergraph/edge/mod.rs
@@ -12,7 +12,7 @@ pub use resolve::{
     Resolve, ResolveEdge, ResolveRecord, RESOLVE, RESOLVE_CONTRACT, REVERSE_RESOLVE,
     REVERSE_RESOLVE_CONTRACT,
 };
-pub use social::{Relation, RelationConnection, RelationEdge};
+pub use social::{Relation, RelationConnection, RelationEdge, RelationResult};
 
 use crate::{
     error::Error,

--- a/src/tigergraph/edge/mod.rs
+++ b/src/tigergraph/edge/mod.rs
@@ -2,6 +2,7 @@ pub mod hold;
 pub mod proof;
 pub mod relation;
 pub mod resolve;
+pub mod social;
 pub use hold::{Hold, HoldRecord, HOLD_CONTRACT, HOLD_IDENTITY};
 pub use proof::{
     Proof, ProofRecord, EDGE_NAME as PROOF_EDGE, REVERSE_EDGE_NAME as PROOF_REVERSE_EDGE,
@@ -11,6 +12,7 @@ pub use resolve::{
     Resolve, ResolveEdge, ResolveRecord, RESOLVE, RESOLVE_CONTRACT, REVERSE_RESOLVE,
     REVERSE_RESOLVE_CONTRACT,
 };
+pub use social::{Relation, RelationConnection, RelationEdge};
 
 use crate::{
     error::Error,

--- a/src/tigergraph/edge/social.rs
+++ b/src/tigergraph/edge/social.rs
@@ -1,8 +1,5 @@
 use crate::{
-    tigergraph::{
-        edge::EdgeRecord,
-        vertex::{ExpandIdentityRecord, IdentityRecord},
-    },
+    tigergraph::{edge::EdgeRecord, vertex::IdentityRecord},
     upstream::DataSource,
     util::{naive_datetime_from_string, naive_datetime_to_string, naive_now},
 };
@@ -79,6 +76,14 @@ impl std::ops::DerefMut for EdgeRecord<RelationConnection> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relation {
     pub relation: RelationEdge,
-    pub original_from: Option<ExpandIdentityRecord>,
-    pub original_to: Option<ExpandIdentityRecord>,
+    pub source_degree: Option<i32>,
+    pub target_degree: Option<i32>,
+    pub original_from: Option<IdentityRecord>,
+    pub original_to: Option<IdentityRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationResult {
+    pub count: i32,
+    pub relation: Vec<Relation>,
 }

--- a/src/tigergraph/edge/social.rs
+++ b/src/tigergraph/edge/social.rs
@@ -1,0 +1,84 @@
+use crate::{
+    tigergraph::{
+        edge::EdgeRecord,
+        vertex::{ExpandIdentityRecord, IdentityRecord},
+    },
+    upstream::DataSource,
+    util::{naive_datetime_from_string, naive_datetime_to_string, naive_now},
+};
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationConnection {
+    pub edge_type: String,
+    pub tag: Option<String>,
+    #[serde(rename = "source")]
+    /// Data source (upstream) which provides this info.
+    pub data_source: DataSource,
+    /// The original follower/following elationship comes from specified identity
+    pub original_from: String,
+    /// The original follower/following elationship comes from specified identity
+    pub original_to: String,
+    /// When this HODL™ relation is fetched by us RelationService.
+    #[serde(deserialize_with = "naive_datetime_from_string")]
+    #[serde(serialize_with = "naive_datetime_to_string")]
+    pub updated_at: NaiveDateTime,
+}
+
+impl Default for RelationConnection {
+    fn default() -> Self {
+        Self {
+            tag: Some("".to_string()),
+            edge_type: "".to_string(),
+            data_source: DataSource::default(),
+            original_from: "".to_string(),
+            original_to: "".to_string(),
+            updated_at: naive_now(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RelationEdge(pub EdgeRecord<RelationConnection>);
+
+impl From<EdgeRecord<RelationConnection>> for RelationEdge {
+    fn from(record: EdgeRecord<RelationConnection>) -> Self {
+        RelationEdge(record)
+    }
+}
+
+impl std::ops::Deref for RelationEdge {
+    type Target = EdgeRecord<RelationConnection>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RelationEdge {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::ops::Deref for EdgeRecord<RelationConnection> {
+    type Target = RelationConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.attributes
+    }
+}
+
+impl std::ops::DerefMut for EdgeRecord<RelationConnection> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.attributes
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Relation {
+    pub relation: RelationEdge,
+    pub original_from: Option<ExpandIdentityRecord>,
+    pub original_to: Option<ExpandIdentityRecord>,
+}

--- a/src/tigergraph/tests.rs
+++ b/src/tigergraph/tests.rs
@@ -293,6 +293,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_follow() -> Result<(), Error> {
+        let client = make_http_client();
+        if let Some(found) = IdentityGraph::find_graph_by_platform_identity(
+            &client,
+            &Platform::Lens,
+            "sujiyan.lens",
+            None,
+        )
+        .await?
+        {
+            let result = found.follow(&client, 1, None, 200, 0).await?;
+
+            // println!("found = {:?}", found);
+            let json_raw =
+                serde_json::to_string(&found).map_err(|err| Error::JSONParseError(err))?;
+            println!("test_identity_graph: {}", json_raw);
+
+            let result_raw: String =
+                serde_json::to_string(&result).map_err(|err| Error::JSONParseError(err))?;
+            println!("follow result: {}", result_raw);
+        } else {
+            // return Err(Error::NoResult);
+            println!("identity_graph not exists.");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_t() -> Result<(), Error> {
         let json_string = r###"
         {

--- a/src/tigergraph/vertex/identity_graph.rs
+++ b/src/tigergraph/vertex/identity_graph.rs
@@ -2,16 +2,19 @@ use crate::{
     config::C,
     error::Error,
     tigergraph::{
+        edge::{EdgeRecord, Relation, RelationConnection, RelationEdge},
         vertex::{Identity, IdentityRecord, VertexRecord},
         BaseResponse, Graph,
     },
     upstream::{Chain, DataSource, Platform},
     util::parse_body,
 };
+use chrono::NaiveDateTime;
 use http::uri::InvalidUri;
 use hyper::{client::HttpConnector, Body, Client, Method};
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, str::FromStr};
 use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -48,6 +51,35 @@ struct SingleExpandIdentityResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct ExpandVerticesList {
     expand_vlist: Vec<ExpandIdentityRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RelationResponse {
+    #[serde(flatten)]
+    base: BaseResponse,
+    results: Option<Vec<RelationTopology>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationTopology {
+    pub edges: Vec<ExpandRelation>,
+    pub vertices: Vec<IdentitiesGraphStatistic>,
+    pub original_vertices: Vec<ExpandIdentityRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentitiesGraphStatistic {
+    pub attributes: Statistic,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Statistic {
+    #[serde(rename = "id")]
+    pub graph_id: String,
+    #[serde(rename = "@range")]
+    pub range: i32,
+    #[serde(rename = "@degree")]
+    pub degree: i32,
 }
 
 impl IdentityGraph {
@@ -121,6 +153,7 @@ impl IdentityGraph {
             }
         }
     }
+
     pub async fn find_graph_by_platform_identity(
         client: &Client<HttpConnector>,
         platform: &Platform,
@@ -216,6 +249,170 @@ impl IdentityGraph {
             }
         }
     }
+
+    pub async fn follow(
+        &self,
+        client: &Client<HttpConnector>,
+        hop: u16,
+        data_source: Option<Vec<DataSource>>,
+        limit: u16,
+        offset: u16,
+    ) -> Result<Option<Vec<Relation>>, Error> {
+        let uri: http::Uri;
+        if data_source.is_none() || data_source.as_ref().unwrap().len() == 0 {
+            uri = format!(
+                "{}/query/{}/social_follows?g={}&hop={}&numPerPage={}&pageNum={}",
+                C.tdb.host,
+                Graph::SocialGraph.to_string(),
+                self.graph_id.to_string(),
+                hop,
+                limit,
+                offset
+            )
+            .parse()
+            .map_err(|_err: InvalidUri| {
+                Error::ParamError(format!("query social_follows Uri format Error {}", _err))
+            })?;
+        } else {
+            let sources: Vec<String> = data_source
+                .unwrap()
+                .into_iter()
+                .map(|field| format!("sources={}", field.to_string()))
+                .collect();
+            let combined = sources.join("&");
+            uri = format!(
+                "{}/query/{}/nfts?g={}&hop={}&{}&numPerPage={}&pageNum={}",
+                C.tdb.host,
+                Graph::SocialGraph.to_string(),
+                self.graph_id.to_string(),
+                hop,
+                combined,
+                limit,
+                offset
+            )
+            .parse()
+            .map_err(|_err: InvalidUri| {
+                Error::ParamError(format!("query social_follows  Uri format Error {}", _err))
+            })?;
+        }
+
+        let req = hyper::Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .header("Authorization", Graph::SocialGraph.token())
+            .body(Body::empty())
+            .map_err(|_err| {
+                Error::ParamError(format!("query social_follows ParamError Error {}", _err))
+            })?;
+
+        let mut resp = client.request(req).await.map_err(|err| {
+            Error::ManualHttpClientError(format!(
+                "query social_follows | Fail to request: {:?}",
+                err.to_string()
+            ))
+        })?;
+
+        match parse_body::<RelationResponse>(&mut resp).await {
+            Ok(r) => {
+                if r.base.error {
+                    let err_message = format!(
+                        "TigerGraph query follow_relation error | Code: {:?}, Message: {:?}",
+                        r.base.code, r.base.message
+                    );
+                    error!(err_message);
+                    return Err(Error::General(err_message, resp.status()));
+                }
+                if let Some(relations) = r.results.and_then(|res| res.first().cloned()) {
+                    let identity_map: HashMap<String, ExpandIdentityRecord> = relations
+                        .original_vertices
+                        .into_iter()
+                        .map(|record| (record.v_id.clone(), record))
+                        .collect();
+
+                    let relation_edges: Vec<Relation> = relations
+                        .edges
+                        .into_iter()
+                        .map(|expand| {
+                            let original_from = identity_map.get(&expand.original_from).cloned();
+                            let original_to = identity_map.get(&expand.original_to).cloned();
+                            let edge = Relation {
+                                relation: expand.record,
+                                original_from,
+                                original_to,
+                            };
+                            edge
+                        })
+                        .collect();
+                    return Ok(Some(relation_edges));
+                } else {
+                    return Ok(Some(vec![]));
+                }
+            }
+            Err(err) => {
+                let err_message = format!(
+                    "TigerGraph query social_follows parse_body error: {:?}",
+                    err
+                );
+                error!(err_message);
+                return Err(err);
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct VertexIds {
+    ids: Vec<String>,
+}
+
+pub async fn query_identity_graph_by_ids(
+    client: &Client<HttpConnector>,
+    ids: Vec<String>,
+) -> Result<Vec<IdentityGraph>, Error> {
+    let uri: http::Uri = format!(
+        "{}/query/{}/query_identity_graph_by_ids",
+        C.tdb.host,
+        Graph::SocialGraph.to_string()
+    )
+    .parse()
+    .map_err(|_err: InvalidUri| Error::ParamError(format!("Uri format Error {}", _err)))?;
+    let payload = VertexIds { ids };
+    let json_params = serde_json::to_string(&payload).map_err(|err| Error::JSONParseError(err))?;
+    let req = hyper::Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header("Authorization", Graph::SocialGraph.token())
+        .body(Body::from(json_params))
+        .map_err(|_err| Error::ParamError(format!("ParamError Error {}", _err)))?;
+    let mut resp = client.request(req).await.map_err(|err| {
+        Error::ManualHttpClientError(format!(
+            "TigerGraph | Fail to query_identity_graph_by_ids: {:?}",
+            err.to_string()
+        ))
+    })?;
+    match parse_body::<IdentityGraphResponse>(&mut resp).await {
+        Ok(r) => {
+            if r.base.error {
+                let err_message = format!(
+                    "TigerGraph query_identity_graph_by_ids error | Code: {:?}, Message: {:?}",
+                    r.base.code, r.base.message
+                );
+                error!(err_message);
+                return Err(Error::General(err_message, resp.status()));
+            }
+
+            let result = r.results.map_or(vec![], |res| res);
+            Ok(result)
+        }
+        Err(err) => {
+            let err_message = format!(
+                "TigerGraph query_identity_graph_by_ids parse_body error: {:?}",
+                err
+            );
+            error!(err_message);
+            return Err(err);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -223,6 +420,11 @@ pub struct ExpandIdentityRecord {
     pub record: IdentityRecord,
     pub owner_address: Option<Vec<Address>>,
     pub resolve_address: Option<Vec<Address>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExpandRelation {
+    pub record: RelationEdge,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -241,6 +443,109 @@ impl std::ops::Deref for ExpandIdentityRecord {
     type Target = IdentityRecord;
     fn deref(&self) -> &Self::Target {
         &self.record
+    }
+}
+
+impl std::ops::DerefMut for ExpandRelation {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.record
+    }
+}
+
+impl std::ops::Deref for ExpandRelation {
+    type Target = RelationEdge;
+    fn deref(&self) -> &Self::Target {
+        &self.record
+    }
+}
+
+impl<'de> Deserialize<'de> for ExpandRelation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ExpandRelationRecordVisitor;
+        impl<'de> Visitor<'de> for ExpandRelationRecordVisitor {
+            type Value = ExpandRelation;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct ExpandRelation")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let e_type: String = "Follow".to_string();
+                let directed: bool = true;
+                let from_type: String = "IdentitiesGraph".to_string();
+                let to_type: String = "IdentitiesGraph".to_string();
+
+                let mut source_v: Option<String> = None;
+                let mut target_v: Option<String> = None;
+                let mut original_from: Option<String> = None;
+                let mut original_to: Option<String> = None;
+                let mut data_source: Option<String> = None;
+                let mut edge_type: Option<String> = None;
+                let mut tag: Option<String> = None;
+                let mut updated_at_str: Option<String> = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        "source_v" => source_v = Some(map.next_value()?),
+                        "target_v" => target_v = Some(map.next_value()?),
+                        "original_from" => original_from = Some(map.next_value()?),
+                        "original_to" => original_to = Some(map.next_value()?),
+                        "data_source" => data_source = Some(map.next_value()?),
+                        "edge_type" => edge_type = Some(map.next_value()?),
+                        "tag" => tag = Some(map.next_value()?),
+                        "updated_at" => tag = Some(map.next_value()?),
+                        _ => {}
+                    }
+                }
+
+                let from_id = source_v.ok_or_else(|| de::Error::missing_field("source_v"))?;
+                let to_id = target_v.ok_or_else(|| de::Error::missing_field("target_v"))?;
+
+                let edge_type = edge_type.ok_or_else(|| de::Error::missing_field("edge_type"))?;
+                let tag = tag.ok_or_else(|| de::Error::missing_field("tag"))?;
+                let data_source =
+                    data_source.ok_or_else(|| de::Error::missing_field("data_source"))?;
+                let original_from =
+                    original_from.ok_or_else(|| de::Error::missing_field("original_from"))?;
+                let original_to =
+                    original_to.ok_or_else(|| de::Error::missing_field("original_to"))?;
+                let updated_at_str =
+                    updated_at_str.ok_or_else(|| de::Error::missing_field("updated_at"))?;
+
+                let updated_at =
+                    NaiveDateTime::parse_from_str(&updated_at_str, "%Y-%m-%d %H:%M:%S")
+                        .map_err(serde::de::Error::custom)?;
+                let attributes = RelationConnection {
+                    edge_type,
+                    tag: Some(tag),
+                    data_source: DataSource::from_str(data_source.as_str())
+                        .unwrap_or(DataSource::Unknown),
+                    original_from,
+                    original_to,
+                    updated_at,
+                };
+                let edge_record = RelationEdge(EdgeRecord {
+                    e_type,
+                    directed,
+                    from_id,
+                    from_type,
+                    to_id,
+                    to_type,
+                    discriminator: None,
+                    attributes,
+                });
+                let expand_record = ExpandRelation {
+                    record: edge_record,
+                };
+                Ok(expand_record)
+            }
+        }
+        deserializer.deserialize_map(ExpandRelationRecordVisitor)
     }
 }
 

--- a/src/tigergraph/vertex/mod.rs
+++ b/src/tigergraph/vertex/mod.rs
@@ -7,7 +7,9 @@ pub use identity::{
     ExpireTimeLoadFn, Identity, IdentityLoadFn, IdentityRecord, IdentityWithSource,
     NeighborReverseLoadFn, NeighborsResponse, OwnerLoadFn,
 };
-pub use identity_graph::{Address, ExpandIdentityRecord, IdentityConnection, IdentityGraph};
+pub use identity_graph::{
+    query_identity_graph_by_ids, Address, ExpandIdentityRecord, IdentityConnection, IdentityGraph,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 


### PR DESCRIPTION
feature: [#133](https://github.com/NextDotID/relation_server/issues/133)

### Feature
1. More adaptable to various situations RelationResult return
Including but not limited to social_data, poap, token_transfer, NFT in commons

2. Added count field for auxiliary paging
3. Added limit and offset fields for paging function, sorting in reverse order according to hyper vertex degree
4. Optimized the return result, giving priority to relationships of `mutual follow` in onchain data.


```
query {
  relation(platform: "lens", identity: "sujiyan.lens") {
    identityGraph {
      graphId
    }
    follow(hop: 1, limit: 200, offset: 0) {
      count
      relation {
        edgeType
        tag
        dataSource
        source
        target
        sourceDegree
        targetDegree
        originalSource {
          id
          uuid
          identity
          platform
          displayName
          uid
        }
        originalTarget {
          id
          uuid
          identity
          platform
          displayName
          uid
        }
      }
    }
  }
}
```

