### PR TITLE
Optimize/batch-upsert

### DIFF
--- a/config/main.sample.toml
+++ b/config/main.sample.toml
@@ -14,7 +14,7 @@ url = "https://proof-service.next.id"
 api_key = "x-api-key"
 
 [upstream.aggregation_service]
-url = "https://7x16bogxfb.execute-api.us-east-1.amazonaws.com/v1/identity/search"
+url = "http://ec2-18-167-90-166.ap-east-1.compute.amazonaws.com/data_server"
 
 [upstream.sybil_service]
 url = "https://raw.githubusercontent.com/Uniswap/sybil-list/master/verified.json"

--- a/config/main.sample.toml
+++ b/config/main.sample.toml
@@ -14,14 +14,14 @@ url = "https://proof-service.next.id"
 api_key = "x-api-key"
 
 [upstream.aggregation_service]
-url = "http://ec2-18-167-90-166.ap-east-1.compute.amazonaws.com/data_server"
+url = "http://data-server-hostname/data_server"
 
 [upstream.sybil_service]
 url = "https://raw.githubusercontent.com/Uniswap/sybil-list/master/verified.json"
 
 [upstream.keybase_service]
 url = "https://keybase.io/_/api/1.0/user/lookup.json"
-stable_url = "http://ec2-18-167-90-166.ap-east-1.compute.amazonaws.com/data_server/keybase"
+stable_url = "http://data-server-hostname/data_server/keybase"
 
 [upstream.knn3_service]
 url = "https://mw.graphql.knn3.xyz/"
@@ -62,4 +62,4 @@ url = "https://indexer.crossbell.io/v1/graphql"
 rpc_url = "https://api.mainnet-beta.solana.com"
 
 [upstream.genome_api]
-rpc_url = "http://ec2-18-167-90-166.ap-east-1.compute.amazonaws.com/data_server/genome"
+rpc_url = "http://data-server-hostname/data_server/genome"

--- a/src/config/tdb/migrations/LoadingJob_SocialGraph.gsql
+++ b/src/config/tdb/migrations/LoadingJob_SocialGraph.gsql
@@ -2,6 +2,61 @@ CREATE GRAPH SocialGraph (Identities, Proof_Forward, Proof_Backward, Contracts, 
 
 USE GRAPH SocialGraph
 
+CREATE OR REPLACE QUERY insert_contract_connection(STRING edges_str) FOR GRAPH SocialGraph SYNTAX v2 {
+  JSONARRAY edges = parse_json_array(edges_str);
+  SumAccum<INT> @@created_edges;
+  INT array_size = edges.size();
+  FOREACH idx IN RANGE[0, array_size - 1] DO
+    JSONOBJECT edge_obj = edges.getJsonObject(idx);
+    STRING edge_type = edge_obj.getString("edge_type");
+    STRING from_id = edge_obj.getString("from_id");
+    STRING to_id = edge_obj.getString("to_id");
+    IF edge_type == "Hold_Contract" THEN
+      INSERT INTO Hold_Contract(FROM, TO, DISCRIMINATOR(source, transaction, id), uuid, created_at, updated_at, fetcher, expired_at)
+        VALUES (
+          from_id Identities,
+          to_id Contracts,
+          edge_obj.getString("source"),
+          edge_obj.getString("transaction"),
+          edge_obj.getString("id"),
+          edge_obj.getString("uuid"),
+          to_datetime(edge_obj.getString("created_at")),
+          now(),
+          edge_obj.getString("fetcher"),
+          to_datetime(edge_obj.getString("expired_at"))
+        );
+      @@created_edges += 1;
+    ELSE IF edge_type == "Reverse_Resolve_Contract" THEN
+      INSERT INTO Reverse_Resolve_Contract(FROM, TO, DISCRIMINATOR(source, system, name), uuid, updated_at, fetcher)
+        VALUES (
+          from_id Identities,
+          to_id Contracts,
+          edge_obj.getString("source"),
+          edge_obj.getString("system"),
+          edge_obj.getString("name"),
+          edge_obj.getString("uuid"),
+          now(),
+          edge_obj.getString("fetcher")
+        );
+      @@created_edges += 1;
+    ELSE IF edge_type == "Resolve_Contract" THEN
+      INSERT INTO Resolve_Contract(FROM, TO, DISCRIMINATOR(source, system, name), uuid, updated_at, fetcher)
+        VALUES (
+          from_id Contracts,
+          to_id Identities,
+          edge_obj.getString("source"),
+          edge_obj.getString("system"),
+          edge_obj.getString("name"),
+          edge_obj.getString("uuid"),
+          now(),
+          edge_obj.getString("fetcher")
+        );
+      @@created_edges += 1;
+    END;
+  END;
+  PRINT @@created_edges as created_edges;
+}
+
 CREATE OR REPLACE QUERY upsert_isolated_vertex(STRING vertex_str, INT updated_nanosecond) FOR GRAPH SocialGraph SYNTAX v2 {
   TYPEDEF TUPLE< INT updated_nanosecond, STRING id > MinUpdatedTimeTuple;
   JSONOBJECT from_v = parse_json_object(vertex_str);

--- a/src/tigergraph/edge/hold.rs
+++ b/src/tigergraph/edge/hold.rs
@@ -225,7 +225,7 @@ impl Transfer for HoldRecord {
         attributes_map
     }
 
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let mut map = Map::new();
         map.insert("uuid".to_string(), json!(self.uuid));
         map.insert("source".to_string(), json!(self.source));
@@ -246,7 +246,7 @@ impl Transfer for HoldRecord {
             self.expired_at
                 .map_or(json!("1970-01-01 00:00:00"), |expired_at| json!(expired_at)),
         );
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/edge/mod.rs
+++ b/src/tigergraph/edge/mod.rs
@@ -1,8 +1,10 @@
 pub mod hold;
+pub mod part_of_identities_graph;
 pub mod proof;
 pub mod relation;
 pub mod resolve;
 pub use hold::{Hold, HoldRecord, HOLD_CONTRACT, HOLD_IDENTITY};
+pub use part_of_identities_graph::{HyperEdge, HyperEdgeRecord, HYPER_EDGE, HYPER_EDGE_REVERSE};
 pub use proof::{
     Proof, ProofRecord, EDGE_NAME as PROOF_EDGE, REVERSE_EDGE_NAME as PROOF_REVERSE_EDGE,
 };

--- a/src/tigergraph/edge/part_of_identities_graph.rs
+++ b/src/tigergraph/edge/part_of_identities_graph.rs
@@ -92,9 +92,9 @@ impl Transfer for HyperEdgeRecord {
         attributes_map
     }
 
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let map = Map::new();
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/edge/part_of_identities_graph.rs
+++ b/src/tigergraph/edge/part_of_identities_graph.rs
@@ -1,0 +1,174 @@
+use crate::{
+    error::Error,
+    tigergraph::{
+        edge::{Edge, EdgeRecord, EdgeWrapper, FromWithParams, Wrapper},
+        vertex::{IdentitiesGraph, Identity, Vertex, VertexRecord},
+        Attribute, Transfer,
+    },
+};
+
+use hyper::{client::HttpConnector, Client};
+use serde::{Deserialize, Serialize};
+use serde_json::value::{Map, Value};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+// always IdentitiesGraph -> Identities
+pub const HYPER_EDGE: &str = "PartOfIdentitiesGraph_Reverse";
+pub const HYPER_EDGE_REVERSE: &str = "PartOfIdentitiesGraph_Reverse";
+pub const IS_DIRECTED: bool = true;
+
+/// HyperEdge
+#[derive(Clone, Deserialize, Serialize, Debug)]
+pub struct HyperEdge {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HyperEdgeRecord(pub EdgeRecord<HyperEdge>);
+
+impl FromWithParams<HyperEdge> for EdgeRecord<HyperEdge> {
+    fn from_with_params(
+        e_type: String,
+        directed: bool,
+        from_id: String,
+        from_type: String,
+        to_id: String,
+        to_type: String,
+        attributes: HyperEdge,
+    ) -> Self {
+        EdgeRecord {
+            e_type,
+            directed,
+            from_id,
+            from_type,
+            to_id,
+            to_type,
+            discriminator: None,
+            attributes,
+        }
+    }
+}
+
+impl From<EdgeRecord<HyperEdge>> for HyperEdgeRecord {
+    fn from(record: EdgeRecord<HyperEdge>) -> Self {
+        HyperEdgeRecord(record)
+    }
+}
+
+impl std::ops::Deref for HyperEdgeRecord {
+    type Target = EdgeRecord<HyperEdge>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for HyperEdgeRecord {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::ops::Deref for EdgeRecord<HyperEdge> {
+    type Target = HyperEdge;
+
+    fn deref(&self) -> &Self::Target {
+        &self.attributes
+    }
+}
+
+impl std::ops::DerefMut for EdgeRecord<HyperEdge> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.attributes
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HyperEdgeAttribute(HashMap<String, Attribute>);
+
+// Implement the `From` trait for converting `HyperEdgeRecord` into a `HashMap<String, Attr>`.
+impl Transfer for HyperEdgeRecord {
+    fn to_attributes_map(&self) -> HashMap<String, Attribute> {
+        let attributes_map = HashMap::new();
+        attributes_map
+    }
+
+    fn to_json_value(&self) -> Value {
+        let map = Map::new();
+        Value::Object(map)
+    }
+}
+
+#[async_trait::async_trait]
+impl Edge<IdentitiesGraph, Identity, HyperEdgeRecord> for HyperEdgeRecord {
+    fn e_type(&self) -> String {
+        self.e_type.clone()
+    }
+
+    fn directed(&self) -> bool {
+        // TODO: query from server is the best solution
+        self.directed.clone()
+    }
+
+    /// Find an edge by UUID.
+    async fn find_by_uuid(
+        _client: &Client<HttpConnector>,
+        _uuid: &Uuid,
+    ) -> Result<Option<HyperEdgeRecord>, Error> {
+        todo!()
+    }
+
+    /// Find `EdgeRecord` by source and target
+    async fn find_by_from_to(
+        &self,
+        _client: &Client<HttpConnector>,
+        _from: &VertexRecord<IdentitiesGraph>,
+        _to: &VertexRecord<Identity>,
+        _filter: Option<HashMap<String, String>>,
+    ) -> Result<Option<Vec<HyperEdgeRecord>>, Error> {
+        todo!()
+    }
+
+    /// Connect 2 vertex.
+    async fn connect(
+        &self,
+        _client: &Client<HttpConnector>,
+        _from: &IdentitiesGraph,
+        _to: &Identity,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    /// notice this function is deprecated
+    async fn connect_reverse(
+        &self,
+        _client: &Client<HttpConnector>,
+        _from: &IdentitiesGraph,
+        _to: &Identity,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+impl Wrapper<HyperEdgeRecord, IdentitiesGraph, Identity> for HyperEdge {
+    fn wrapper(
+        &self,
+        from: &IdentitiesGraph,
+        to: &Identity,
+        name: &str,
+    ) -> EdgeWrapper<HyperEdgeRecord, IdentitiesGraph, Identity> {
+        let part_of = EdgeRecord::from_with_params(
+            name.to_string(),
+            IS_DIRECTED,
+            from.primary_key(),
+            from.vertex_type(),
+            to.primary_key(),
+            to.vertex_type(),
+            self.to_owned(),
+        );
+        EdgeWrapper {
+            edge: HyperEdgeRecord(part_of),
+            source: from.to_owned(),
+            target: to.to_owned(),
+        }
+    }
+}

--- a/src/tigergraph/edge/proof.rs
+++ b/src/tigergraph/edge/proof.rs
@@ -191,7 +191,7 @@ impl Transfer for ProofRecord {
         attributes_map
     }
 
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let mut map = Map::new();
         map.insert("uuid".to_string(), json!(self.uuid));
         map.insert("source".to_string(), json!(self.source));
@@ -207,7 +207,7 @@ impl Transfer for ProofRecord {
         );
         map.insert("updated_at".to_string(), json!(self.updated_at));
         map.insert("fetcher".to_string(), json!(self.fetcher));
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/edge/resolve.rs
+++ b/src/tigergraph/edge/resolve.rs
@@ -187,7 +187,7 @@ impl Transfer for ResolveRecord {
         );
         attributes_map
     }
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let mut map = Map::new();
         map.insert("uuid".to_string(), json!(self.uuid));
         map.insert("source".to_string(), json!(self.source));
@@ -195,7 +195,7 @@ impl Transfer for ResolveRecord {
         map.insert("name".to_string(), json!(self.name));
         map.insert("fetcher".to_string(), json!(self.fetcher));
         map.insert("updated_at".to_string(), json!(self.updated_at));
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/upsert.rs
+++ b/src/tigergraph/upsert.rs
@@ -17,6 +17,7 @@ use http::uri::InvalidUri;
 use hyper::Method;
 use hyper::{client::HttpConnector, Body, Client};
 use serde::{Deserialize, Serialize};
+use serde_json::value::Value;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use tracing::{error, trace};
@@ -286,12 +287,12 @@ where
         let from_record = VertexRecord::from_with_json_value(
             warpper.source.vertex_type(),
             warpper.source.primary_key(),
-            warpper.source.to_json_value(),
+            Value::Object(warpper.source.to_json_value()),
         );
         let to_record = VertexRecord::from_with_json_value(
             warpper.target.vertex_type(),
             warpper.target.primary_key(),
-            warpper.target.to_json_value(),
+            Value::Object(warpper.target.to_json_value()),
         );
         let from_str =
             serde_json::to_string(&from_record).map_err(|err| Error::JSONParseError(err))?;
@@ -319,7 +320,7 @@ where
         let vertex_record = VertexRecord::from_with_json_value(
             warpper.vertex.vertex_type(),
             warpper.vertex.primary_key(),
-            warpper.vertex.to_json_value(),
+            Value::Object(warpper.vertex.to_json_value()),
         );
         let vertex_str =
             serde_json::to_string(&vertex_record).map_err(|err| Error::JSONParseError(err))?;

--- a/src/tigergraph/vertex/contract.rs
+++ b/src/tigergraph/vertex/contract.rs
@@ -188,7 +188,7 @@ impl Transfer for Contract {
         attributes_map
     }
 
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let mut map = Map::new();
         map.insert("id".to_string(), json!(self.primary_key()));
         map.insert("uuid".to_string(), json!(self.uuid));
@@ -200,7 +200,7 @@ impl Transfer for Contract {
             json!(self.symbol.clone().unwrap_or("".to_string())),
         );
         map.insert("updated_at".to_string(), json!(self.updated_at));
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/vertex/contract.rs
+++ b/src/tigergraph/vertex/contract.rs
@@ -18,6 +18,7 @@ use hyper::{client::HttpConnector, Body, Client, Method};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::value::{Map, Value};
+use std::any::Any;
 use std::collections::HashMap;
 use tracing::{error, trace};
 use uuid::Uuid;
@@ -71,6 +72,10 @@ impl Vertex for Contract {
 
     fn vertex_type(&self) -> String {
         VERTEX_NAME.to_string()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/tigergraph/vertex/identity.rs
+++ b/src/tigergraph/vertex/identity.rs
@@ -28,6 +28,7 @@ use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use serde_json::value::{Map, Value};
+use std::any::Any;
 use std::collections::HashMap;
 use std::fmt;
 use tracing::{error, trace};
@@ -90,6 +91,10 @@ impl Vertex for Identity {
 
     fn vertex_type(&self) -> String {
         VERTEX_NAME.to_string()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/tigergraph/vertex/identity.rs
+++ b/src/tigergraph/vertex/identity.rs
@@ -280,7 +280,7 @@ impl Transfer for Identity {
         attributes_map
     }
 
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let mut map = Map::new();
         map.insert("id".to_string(), json!(self.primary_key()));
         map.insert(
@@ -321,7 +321,7 @@ impl Transfer for Identity {
             "reverse".to_string(),
             self.reverse.map_or(json!(false), |reverse| json!(reverse)),
         );
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/vertex/identity_graph.rs
+++ b/src/tigergraph/vertex/identity_graph.rs
@@ -132,14 +132,14 @@ impl Transfer for IdentitiesGraph {
         attributes_map
     }
 
-    fn to_json_value(&self) -> Value {
+    fn to_json_value(&self) -> Map<String, Value> {
         let mut map = Map::new();
         map.insert("id".to_string(), json!(self.id));
         map.insert(
             "updated_nanosecond".to_string(),
             json!(self.updated_nanosecond),
         );
-        Value::Object(map)
+        map
     }
 }
 

--- a/src/tigergraph/vertex/mod.rs
+++ b/src/tigergraph/vertex/mod.rs
@@ -10,6 +10,7 @@ pub use identity::{
 pub use identity_graph::{Address, ExpandIdentityRecord, IdentityConnection, IdentityGraph};
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
+use std::any::Any;
 
 /// All `Vertex` records.
 #[async_trait]
@@ -17,6 +18,8 @@ pub trait Vertex {
     fn primary_key(&self) -> String;
 
     fn vertex_type(&self) -> String;
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/tigergraph/vertex/mod.rs
+++ b/src/tigergraph/vertex/mod.rs
@@ -7,7 +7,9 @@ pub use identity::{
     ExpireTimeLoadFn, Identity, IdentityLoadFn, IdentityRecord, IdentityWithSource,
     NeighborReverseLoadFn, NeighborsResponse, OwnerLoadFn,
 };
-pub use identity_graph::{Address, ExpandIdentityRecord, IdentityConnection, IdentityGraph};
+pub use identity_graph::{
+    Address, ExpandIdentityRecord, IdentitiesGraph, IdentityConnection, IdentityGraph,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 use std::any::Any;

--- a/src/upstream/aggregation/mod.rs
+++ b/src/upstream/aggregation/mod.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::tigergraph::edge::Proof;
 use crate::tigergraph::upsert::create_identity_to_identity_proof_two_way_binding;
 use crate::tigergraph::vertex::Identity;
+use crate::tigergraph::EdgeList;
 use crate::upstream::{DataSource, Fetcher, Platform, ProofLevel, TargetProcessedList};
 use crate::util::{
     make_client, make_http_client, naive_now, parse_body, request_with_timeout, timestamp_to_naive,
@@ -59,6 +60,13 @@ impl Fetcher for Aggregation {
             }
             Target::NFT(_, _, _, _) => todo!(),
         }
+    }
+
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+        Ok((vec![], vec![]))
     }
 
     fn can_fetch(target: &Target) -> bool {

--- a/src/upstream/crossbell/mod.rs
+++ b/src/upstream/crossbell/mod.rs
@@ -117,7 +117,7 @@ impl Fetcher for Crossbell {
         }
     }
 
-    async fn fetch_and_save(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
         if !Self::can_fetch(target) {
             return Ok((vec![], vec![]));
         }

--- a/src/upstream/crossbell/mod.rs
+++ b/src/upstream/crossbell/mod.rs
@@ -3,11 +3,13 @@ mod tests;
 
 use crate::config::C;
 use crate::error::Error;
-use crate::tigergraph::edge::{Hold, Resolve};
+use crate::tigergraph::edge::{Hold, HyperEdge, Resolve, Wrapper};
+use crate::tigergraph::edge::{HOLD_IDENTITY, HYPER_EDGE, RESOLVE, REVERSE_RESOLVE};
 use crate::tigergraph::upsert::create_identity_domain_resolve_record;
 use crate::tigergraph::upsert::create_identity_domain_reverse_resolve_record;
 use crate::tigergraph::upsert::create_identity_to_identity_hold_record;
-use crate::tigergraph::vertex::Identity;
+use crate::tigergraph::vertex::{IdentitiesGraph, Identity};
+use crate::tigergraph::{EdgeList, EdgeWrapperEnum};
 use crate::upstream::{
     DataFetcher, DataSource, DomainNameSystem, Fetcher, Platform, Target, TargetProcessedList,
 };
@@ -115,9 +117,203 @@ impl Fetcher for Crossbell {
         }
     }
 
+    async fn fetch_and_save(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        match target.platform()? {
+            Platform::Ethereum => batch_fetch_by_wallet(target).await,
+            Platform::Crossbell => batch_fetch_by_handle(target).await,
+            _ => Ok((vec![], vec![])),
+        }
+    }
+
     fn can_fetch(target: &Target) -> bool {
         target.in_platform_supported(vec![Platform::Ethereum, Platform::Crossbell])
     }
+}
+
+async fn query_by_handle(target: &Target) -> Result<Option<QueryResponse>, Error> {
+    let query = QUERY_BY_HANDLE.to_string();
+    let target_var = target.identity()?;
+    let handle = target_var.trim_end_matches(".csb");
+    let client = GQLClient::new(&C.upstream.crossbell_api.url);
+    let vars = QueryVars {
+        target: handle.to_string(),
+    };
+    let resp = client.query_with_vars::<QueryResponse, QueryVars>(&query, vars);
+
+    let data: Option<QueryResponse> =
+        match tokio::time::timeout(std::time::Duration::from_secs(5), resp).await {
+            Ok(resp) => match resp {
+                Ok(resp) => resp,
+                Err(err) => {
+                    warn!(?target, ?err, "Crossbell: Failed to fetch");
+                    None
+                }
+            },
+            Err(_) => {
+                warn!(?target, "Crossbell timeout: no response in 5 seconds.");
+                None
+            }
+        };
+
+    Ok(data)
+}
+
+async fn query_by_wallet(target: &Target) -> Result<Option<QueryResponse>, Error> {
+    let query = QUERY_BY_WALLET.to_string();
+    let target_var = target.identity()?;
+    let client = GQLClient::new(&C.upstream.crossbell_api.url);
+    let vars = QueryVars {
+        target: target_var.to_lowercase(),
+    };
+    let resp = client.query_with_vars::<QueryResponse, QueryVars>(&query, vars);
+
+    let data: Option<QueryResponse> =
+        match tokio::time::timeout(std::time::Duration::from_secs(5), resp).await {
+            Ok(resp) => match resp {
+                Ok(resp) => resp,
+                Err(err) => {
+                    warn!(?target, ?err, "Crossbell: Failed to fetch");
+                    None
+                }
+            },
+            Err(_) => {
+                warn!(?target, "Crossbell timeout: no response in 5 seconds.");
+                None
+            }
+        };
+
+    Ok(data)
+}
+
+async fn batch_fetch_by_handle(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let data = query_by_handle(target).await?;
+    if data.is_none() {
+        info!(?target, "Crossbell: No result");
+        return Ok((vec![], vec![]));
+    }
+    let res = data.unwrap();
+    debug!(?target, characters = res.characters.len(), "Records found.");
+
+    let owner = res.characters.first().unwrap().owner.clone().to_lowercase();
+    let mut next_targets = TargetProcessedList::new();
+    next_targets.push(Target::Identity(Platform::Ethereum, owner));
+
+    let edges = generate_edges(&res.characters);
+    Ok((next_targets, edges))
+}
+
+async fn batch_fetch_by_wallet(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let data = query_by_wallet(target).await?;
+    if data.is_none() {
+        info!(?target, "Crossbell: No result");
+        return Ok((vec![], vec![]));
+    }
+    let res = data.unwrap();
+    debug!(?target, characters = res.characters.len(), "Records found.");
+    let edges = generate_edges(&res.characters);
+    // after fetch by wallet, nothing return for next target
+    Ok((vec![], edges))
+}
+
+fn generate_edges(characters: &Vec<Character>) -> EdgeList {
+    let mut edges = EdgeList::new();
+    let hv = IdentitiesGraph::default();
+    for profile in characters.iter() {
+        let handle = profile.handle.clone();
+        let csb = format!("{}.csb", handle);
+        let display_name = profile.metadata.clone().map_or(handle.clone(), |res| {
+            res.content.map_or(handle.clone(), |content| {
+                content.name.map_or(handle.clone(), |name| name)
+            })
+        });
+        let avatar = profile.metadata.clone().map_or(None, |res| {
+            res.content.map_or(None, |content| {
+                content
+                    .avatars
+                    .map_or(None, |avatars| avatars.first().cloned())
+            })
+        });
+
+        let mut crossbell = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Crossbell,
+            identity: csb.clone(),
+            uid: Some(profile.character_id.clone()),
+            created_at: profile.created_at,
+            display_name: Some(display_name),
+            added_at: naive_now(),
+            avatar_url: avatar,
+            profile_url: Some("https://xchar.app/".to_owned() + &profile.handle.clone()),
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+
+        let owner = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Ethereum,
+            identity: profile.owner.clone(),
+            uid: None,
+            created_at: None,
+            display_name: None,
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        let hold: Hold = Hold {
+            uuid: Uuid::new_v4(),
+            source: DataSource::Crossbell,
+            transaction: profile.transaction_hash.clone(),
+            id: profile.character_id.clone(),
+            created_at: None,
+            updated_at: naive_now(),
+            fetcher: DataFetcher::RelationService,
+            expired_at: None,
+        };
+        let resolve: Resolve = Resolve {
+            uuid: Uuid::new_v4(),
+            source: DataSource::Crossbell,
+            system: DomainNameSystem::Crossbell,
+            name: csb.clone(),
+            fetcher: DataFetcher::RelationService,
+            updated_at: naive_now(),
+        };
+
+        if profile.primary {
+            let reverse: Resolve = Resolve {
+                uuid: Uuid::new_v4(),
+                source: DataSource::Crossbell,
+                system: DomainNameSystem::Crossbell,
+                name: csb.clone(),
+                fetcher: DataFetcher::RelationService,
+                updated_at: naive_now(),
+            };
+            crossbell.reverse = Some(true);
+            let rrs = reverse.wrapper(&owner, &crossbell, REVERSE_RESOLVE);
+            edges.push(EdgeWrapperEnum::new_reverse_resolve(rrs));
+        }
+
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &crossbell, HYPER_EDGE),
+        ));
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &owner, HYPER_EDGE),
+        ));
+
+        let hd = hold.wrapper(&owner, &crossbell, HOLD_IDENTITY);
+        let rs = resolve.wrapper(&crossbell, &owner, RESOLVE);
+        edges.push(EdgeWrapperEnum::new_hold_identity(hd));
+        edges.push(EdgeWrapperEnum::new_resolve(rs));
+    }
+
+    edges
 }
 
 async fn fetch_by_wallet(target: &Target) -> Result<TargetProcessedList, Error> {

--- a/src/upstream/dotbit/mod.rs
+++ b/src/upstream/dotbit/mod.rs
@@ -40,7 +40,7 @@ impl Fetcher for DotBit {
         }
     }
 
-    async fn fetch_and_save(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
         if !Self::can_fetch(target) {
             return Ok((vec![], vec![]));
         }

--- a/src/upstream/dotbit/mod.rs
+++ b/src/upstream/dotbit/mod.rs
@@ -748,7 +748,10 @@ async fn fetch_reverse_record(
         return Err(Error::NoResult);
     }
     if resp.result.data.is_none() || resp.result.data.as_ref().unwrap().account.len() == 0 {
-        warn!("das_reverseRecord result is empty, resp {:?}", resp);
+        warn!(
+            "das_reverseRecord result({}) is empty, resp {:?}",
+            identity, resp
+        );
         return Ok(None);
     }
 

--- a/src/upstream/ens_reverse/mod.rs
+++ b/src/upstream/ens_reverse/mod.rs
@@ -3,11 +3,14 @@ mod tests;
 
 use crate::config::C;
 use crate::error::Error;
-use crate::tigergraph::edge::Resolve;
+use crate::tigergraph::edge::{
+    HyperEdge, Resolve, Wrapper, HYPER_EDGE, REVERSE_RESOLVE, REVERSE_RESOLVE_CONTRACT,
+};
 use crate::tigergraph::upsert::create_identity_domain_reverse_resolve_record;
 use crate::tigergraph::upsert::create_identity_to_contract_reverse_resolve_record;
 use crate::tigergraph::upsert::create_isolated_vertex;
-use crate::tigergraph::vertex::{Contract, Identity};
+use crate::tigergraph::vertex::{Contract, IdentitiesGraph, Identity};
+use crate::tigergraph::{EdgeList, EdgeWrapperEnum};
 use crate::upstream::{Chain, ContractCategory, DataFetcher, DataSource, DomainNameSystem};
 use crate::util::{make_client, make_http_client, naive_now, parse_body, request_with_timeout};
 use async_trait::async_trait;
@@ -96,6 +99,89 @@ impl Fetcher for ENSReverseLookup {
         )
         .await?;
         Ok(vec![])
+    }
+
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        let wallet = target.identity().unwrap().to_lowercase();
+        let record = fetch_record(&wallet).await?;
+        // If reverse lookup record is reset to empty by user,
+        // our cache should also be cleared.
+        // Reach this by setting `display_name` into `Some("")`.
+        let reverse_ens = record.reverse_record.clone().unwrap_or("".into());
+        let mut eth_identity = Identity::default();
+        eth_identity.uuid = Some(Uuid::new_v4());
+        eth_identity.platform = Platform::Ethereum;
+        eth_identity.identity = wallet.clone();
+        eth_identity.display_name = Some(reverse_ens.clone());
+
+        let mut edges = EdgeList::new();
+        let hv = IdentitiesGraph::default();
+
+        if reverse_ens == "" {
+            // if ens reverse is empty, we should also saving the ethereum into identity_graph, create a isolated vertex
+            edges.push(EdgeWrapperEnum::new_hyper_edge(HyperEdge {}.wrapper(
+                &hv,
+                &eth_identity,
+                HYPER_EDGE,
+            )));
+            info!(?target, "ENS Reverse record is null");
+            return Ok((vec![], edges));
+        }
+        info!(?target, "ENS Reverse record: {} => {}", wallet, reverse_ens);
+
+        eth_identity.reverse = Some(true); // ethereum and primary ens remain same value
+        let ens_domain = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::ENS,
+            identity: reverse_ens.clone(),
+            uid: None,
+            created_at: None,
+            display_name: Some(reverse_ens.clone()),
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(true),
+        };
+        let contract = Contract {
+            uuid: Uuid::new_v4(),
+            category: ContractCategory::ENS,
+            address: ContractCategory::ENS.default_contract_address().unwrap(),
+            chain: Chain::Ethereum,
+            symbol: None,
+            updated_at: naive_now(),
+        };
+
+        let reverse = Resolve {
+            uuid: Uuid::new_v4(),
+            source: DataSource::TheGraph,
+            system: DomainNameSystem::ENS,
+            name: reverse_ens.clone(),
+            fetcher: DataFetcher::RelationService,
+            updated_at: naive_now(),
+        };
+        // create reverse resolve record
+        let rr = reverse.wrapper(&eth_identity, &ens_domain, REVERSE_RESOLVE);
+        let rrc = reverse.wrapper(&eth_identity, &contract, REVERSE_RESOLVE_CONTRACT);
+        edges.push(EdgeWrapperEnum::new_hyper_edge(HyperEdge {}.wrapper(
+            &hv,
+            &eth_identity,
+            HYPER_EDGE,
+        )));
+        edges.push(EdgeWrapperEnum::new_hyper_edge(HyperEdge {}.wrapper(
+            &hv,
+            &ens_domain,
+            HYPER_EDGE,
+        )));
+        edges.push(EdgeWrapperEnum::new_reverse_resolve(rr));
+        edges.push(EdgeWrapperEnum::new_reverse_resolve_contract(rrc));
+
+        Ok((vec![], edges))
     }
 
     fn can_fetch(target: &Target) -> bool {

--- a/src/upstream/farcaster/mod.rs
+++ b/src/upstream/farcaster/mod.rs
@@ -5,6 +5,7 @@ use crate::error::Error;
 use crate::tigergraph::edge::Hold;
 use crate::tigergraph::upsert::create_identity_to_identity_hold_record;
 use crate::tigergraph::vertex::Identity;
+use crate::tigergraph::EdgeList;
 use crate::upstream::{DataFetcher, DataSource, Fetcher, Platform, Target, TargetProcessedList};
 use crate::util::{make_http_client, naive_now};
 use async_trait::async_trait;
@@ -30,6 +31,19 @@ impl Fetcher for Farcaster {
             Target::NFT(_, _, _, _) => todo!(),
         }
     }
+
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+        match target {
+            Target::Identity(platform, identity) => {
+                warpcast::batch_fetch_connections(platform, identity).await
+            }
+            Target::NFT(_, _, _, _) => todo!(),
+        }
+    }
+
     fn can_fetch(target: &Target) -> bool {
         target.in_platform_supported(vec![Platform::Farcaster, Platform::Ethereum])
     }

--- a/src/upstream/farcaster/tests.rs
+++ b/src/upstream/farcaster/tests.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
     use crate::error::Error;
-    use crate::upstream::farcaster::warpcast::{fetch_by_signer, fetch_by_username};
+    use crate::upstream::farcaster::warpcast::{batch_fetch_by_signer, batch_fetch_by_username};
     use crate::upstream::types::Platform;
 
     #[tokio::test]
     async fn test_get_farcaster_profile_by_username() -> Result<(), Error> {
         let username = "suji";
-        let data = fetch_by_username(&Platform::Farcaster, &username).await?;
+        let data = batch_fetch_by_username(&Platform::Farcaster, &username).await?;
         println!("data: {:?}", data);
         Ok(())
     }
@@ -15,7 +15,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_farcaster_profile_by_signer() -> Result<(), Error> {
         let address = "0x934b510d4c9103e6a87aef13b816fb080286d649";
-        let data = fetch_by_signer(&Platform::Farcaster, &address).await?;
+        let data = batch_fetch_by_signer(&Platform::Farcaster, &address).await?;
         println!("data: {:?}", data);
         Ok(())
     }

--- a/src/upstream/farcaster/warpcast.rs
+++ b/src/upstream/farcaster/warpcast.rs
@@ -53,8 +53,16 @@ pub async fn batch_fetch_by_username(
     let mut edges = EdgeList::new();
     let hv = IdentitiesGraph::default();
     let user = user_by_username(username).await?;
+    if user.is_none() {
+        return Ok((vec![], vec![]));
+    }
+    let user = user.unwrap();
     let fid = user.fid;
     let verifications = get_verifications(fid).await?;
+    if verifications.is_none() {
+        return Ok((vec![], vec![]));
+    }
+    let verifications = verifications.unwrap();
     // isolated vertex
     if verifications.is_empty() {
         let isolated_farcaster: Identity = Identity {
@@ -159,6 +167,14 @@ pub async fn batch_fetch_by_signer(
 
     let fid = user.fid;
     let verifications = get_verifications(fid).await?;
+    if verifications.is_none() {
+        return Ok((vec![], vec![]));
+    }
+    let verifications = verifications.unwrap();
+    if verifications.is_empty() {
+        return Ok((vec![], vec![]));
+    }
+
     for verification in verifications.iter() {
         let protocol: Platform = verification.protocol.parse()?;
         let mut verification_address = verification.address.clone();
@@ -229,8 +245,16 @@ pub async fn fetch_by_username(
 ) -> Result<TargetProcessedList, Error> {
     let cli = make_http_client();
     let user = user_by_username(username).await?;
+    if user.is_none() {
+        return Ok(vec![]);
+    }
+    let user = user.unwrap();
     let fid = user.fid;
     let verifications = get_verifications(fid).await?;
+    if verifications.is_none() {
+        return Ok(vec![]);
+    }
+    let verifications = verifications.unwrap();
     // isolated vertex
     if verifications.is_empty() {
         let u: Identity = Identity {
@@ -275,6 +299,10 @@ pub async fn fetch_by_signer(
     let user = user.unwrap();
     let fid = user.fid;
     let verifications = get_verifications(fid).await?;
+    if verifications.is_none() {
+        return Ok(vec![]);
+    }
+    let verifications = verifications.unwrap();
     for verification in verifications.iter() {
         let target = save_verifications(&cli, &user, verification).await?;
         targets.push(target);
@@ -338,18 +366,14 @@ async fn save_verifications(
 
 // {"errors":[{"message":"No FID associated with username checkyou"}]}
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct WarpcastError {
-    pub errors: Vec<Message>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Message {
     pub message: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UserProfileResponse {
-    pub result: UserProfileResult,
+    pub errors: Option<Vec<Message>>,
+    pub result: Option<UserProfileResult>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -399,7 +423,8 @@ pub struct Location {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct VerificationResponse {
-    pub result: VerificationResult,
+    pub errors: Option<Vec<Message>>,
+    pub result: Option<VerificationResult>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -417,7 +442,7 @@ pub struct Verification {
     pub protocol: String,
 }
 
-async fn user_by_username(username: &str) -> Result<User, Error> {
+async fn user_by_username(username: &str) -> Result<Option<User>, Error> {
     let client = make_client();
     let uri: http::Uri = format!(
         "{}/v2/user-by-username?username={}",
@@ -457,19 +482,29 @@ async fn user_by_username(username: &str) -> Result<User, Error> {
         })?;
 
     let result = match parse_body::<UserProfileResponse>(&mut resp).await {
-        Ok(r) => r,
-        Err(_) => {
-            let w_err = parse_body::<WarpcastError>(&mut resp).await?;
-            let err_message = format!(
-                "Warpcast fetch error| failed to fetch user-by-username?username={}, message: {:?}",
-                username, w_err
-            );
-            error!(err_message);
-            return Err(Error::ManualHttpClientError(err_message));
+        Ok(r) => match r.errors {
+            Some(errors) => {
+                let err_message = format!(
+                    "Warpcast fetch error| failed to fetch user-by-username?username={}, message: {:?}",
+                    username, errors
+                );
+                error!(err_message);
+                None
+            }
+            None => match r.result {
+                None => None,
+                Some(res) => Some(res.user),
+            },
+        },
+        Err(err) => {
+            return Err(Error::ManualHttpClientError(format!(
+                "Warpcast fetch error | parse_body error: {}",
+                err
+            )));
         }
     };
 
-    Ok(result.result.user)
+    Ok(result)
 }
 
 async fn user_by_verification(address: &str) -> Result<Option<User>, Error> {
@@ -524,21 +559,31 @@ async fn user_by_verification(address: &str) -> Result<Option<User>, Error> {
         })?;
 
     let result = match parse_body::<UserProfileResponse>(&mut resp).await {
-        Ok(r) => r,
-        Err(_) => {
-            let w_err = parse_body::<WarpcastError>(&mut resp).await?;
-            let err_message = format!(
-                "Warpcast fetch error| failed to fetch user-by-verification?address={}, message: {:?}",
-                address, w_err
-            );
-            error!(err_message);
-            return Err(Error::ManualHttpClientError(err_message));
+        Ok(r) => match r.errors {
+            Some(errors) => {
+                let err_message = format!(
+                    "Warpcast fetch error| failed to fetch user-by-verification?address={}, message: {:?}",
+                    address, errors
+                );
+                error!(err_message);
+                None
+            }
+            None => match r.result {
+                None => None,
+                Some(res) => Some(res.user),
+            },
+        },
+        Err(err) => {
+            return Err(Error::ManualHttpClientError(format!(
+                "Warpcast fetch error | parse_body error: {}",
+                err
+            )));
         }
     };
-    Ok(Some(result.result.user))
+    Ok(result)
 }
 
-async fn get_verifications(fid: i64) -> Result<Vec<Verification>, Error> {
+async fn get_verifications(fid: i64) -> Result<Option<Vec<Verification>>, Error> {
     let client = make_client();
     let uri: http::Uri = format!(
         "{}/v2/verifications?fid={}",
@@ -578,16 +623,26 @@ async fn get_verifications(fid: i64) -> Result<Vec<Verification>, Error> {
         })?;
 
     let result = match parse_body::<VerificationResponse>(&mut resp).await {
-        Ok(r) => r,
-        Err(_) => {
-            let w_err = parse_body::<WarpcastError>(&mut resp).await?;
-            let err_message = format!(
-                "Warpcast fetch error| failed to fetch verifications?fid={}, message: {:?}",
-                fid, w_err
-            );
-            error!(err_message);
-            return Err(Error::ManualHttpClientError(err_message));
+        Ok(r) => match r.errors {
+            Some(errors) => {
+                let err_message = format!(
+                    "Warpcast fetch error| failed to fetch verifications?fid={}, message: {:?}",
+                    fid, errors
+                );
+                error!(err_message);
+                None
+            }
+            None => match r.result {
+                None => None,
+                Some(res) => Some(res.verifications),
+            },
+        },
+        Err(err) => {
+            return Err(Error::ManualHttpClientError(format!(
+                "Warpcast fetch error | parse_body error: {}",
+                err
+            )));
         }
     };
-    Ok(result.result.verifications)
+    Ok(result)
 }

--- a/src/upstream/farcaster/warpcast.rs
+++ b/src/upstream/farcaster/warpcast.rs
@@ -2,7 +2,13 @@ use crate::{
     config::C,
     error::Error,
     tigergraph::upsert::{create_identity_to_identity_hold_record, create_isolated_vertex},
-    tigergraph::{edge::Hold, vertex::Identity},
+    tigergraph::{
+        EdgeList, EdgeWrapperEnum,
+        {
+            edge::{Hold, HyperEdge, Wrapper, HOLD_IDENTITY, HYPER_EDGE},
+            vertex::{IdentitiesGraph, Identity},
+        },
+    },
     upstream::{DataFetcher, DataSource, Platform, Target, TargetProcessedList},
     util::{
         make_client, make_http_client, naive_datetime_from_milliseconds,
@@ -26,6 +32,195 @@ pub async fn fetch_connections_by_platform_identity(
         Platform::Ethereum => fetch_by_signer(platform, identity).await,
         _ => Ok(vec![]),
     }
+}
+
+pub async fn batch_fetch_connections(
+    platform: &Platform,
+    identity: &str,
+) -> Result<(TargetProcessedList, EdgeList), Error> {
+    match *platform {
+        Platform::Farcaster => batch_fetch_by_username(platform, identity).await,
+        Platform::Ethereum => batch_fetch_by_signer(platform, identity).await,
+        _ => Ok((vec![], vec![])),
+    }
+}
+
+pub async fn batch_fetch_by_username(
+    _platform: &Platform,
+    username: &str,
+) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let mut targets: Vec<Target> = Vec::new();
+    let mut edges = EdgeList::new();
+    let hv = IdentitiesGraph::default();
+    let user = user_by_username(username).await?;
+    let fid = user.fid;
+    let verifications = get_verifications(fid).await?;
+    // isolated vertex
+    if verifications.is_empty() {
+        let isolated_farcaster: Identity = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Farcaster,
+            identity: user.username.clone(),
+            uid: Some(user.fid.to_string()),
+            created_at: None,
+            display_name: Some(user.display_name.clone()),
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        edges.push(EdgeWrapperEnum::new_hyper_edge(HyperEdge {}.wrapper(
+            &hv,
+            &isolated_farcaster,
+            HYPER_EDGE,
+        )));
+        return Ok((vec![], edges));
+    }
+
+    for verification in verifications.iter() {
+        let protocol: Platform = verification.protocol.parse()?;
+        let mut address = verification.address.clone();
+        if protocol == Platform::Ethereum {
+            address = address.to_lowercase();
+        }
+        let wallet: Identity = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: protocol,
+            identity: address.clone(),
+            uid: None,
+            created_at: None,
+            display_name: None,
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        let farcaster: Identity = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Farcaster,
+            identity: user.username.clone(),
+            uid: Some(user.fid.to_string()),
+            created_at: None,
+            display_name: Some(user.display_name.clone()),
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        let hold: Hold = Hold {
+            uuid: Uuid::new_v4(),
+            source: DataSource::Farcaster,
+            transaction: None,
+            id: "".to_string(),
+            created_at: Some(verification.timestamp),
+            updated_at: naive_now(),
+            fetcher: DataFetcher::RelationService,
+            expired_at: None,
+        };
+
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &wallet, HYPER_EDGE),
+        ));
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &farcaster, HYPER_EDGE),
+        ));
+        let hd = hold.wrapper(&wallet, &farcaster, HOLD_IDENTITY);
+        edges.push(EdgeWrapperEnum::new_hold_identity(hd));
+        targets.push(Target::Identity(protocol, address.clone()))
+    }
+
+    Ok((targets, edges))
+}
+
+pub async fn batch_fetch_by_signer(
+    platform: &Platform,
+    address: &str,
+) -> Result<(TargetProcessedList, EdgeList), Error> {
+    if platform.to_owned() == Platform::Solana {
+        // WrapcastV2 not supported user-by-verification?address=solana_address format yet.
+        return Ok((vec![], vec![]));
+    }
+
+    let user = user_by_verification(address).await?;
+    if user.is_none() {
+        return Ok((vec![], vec![]));
+    }
+    let user = user.unwrap();
+
+    let mut targets: Vec<Target> = Vec::new();
+    let mut edges = EdgeList::new();
+    let hv = IdentitiesGraph::default();
+
+    let fid = user.fid;
+    let verifications = get_verifications(fid).await?;
+    for verification in verifications.iter() {
+        let protocol: Platform = verification.protocol.parse()?;
+        let mut verification_address = verification.address.clone();
+        if protocol == Platform::Ethereum {
+            verification_address = verification_address.to_lowercase();
+        }
+        let wallet: Identity = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: protocol,
+            identity: verification_address.clone(),
+            uid: None,
+            created_at: None,
+            display_name: None,
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        let farcaster: Identity = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Farcaster,
+            identity: user.username.clone(),
+            uid: Some(user.fid.to_string()),
+            created_at: None,
+            display_name: Some(user.display_name.clone()),
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        let hold: Hold = Hold {
+            uuid: Uuid::new_v4(),
+            source: DataSource::Farcaster,
+            transaction: None,
+            id: "".to_string(),
+            created_at: Some(verification.timestamp),
+            updated_at: naive_now(),
+            fetcher: DataFetcher::RelationService,
+            expired_at: None,
+        };
+
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &wallet, HYPER_EDGE),
+        ));
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &farcaster, HYPER_EDGE),
+        ));
+        let hd = hold.wrapper(&wallet, &farcaster, HOLD_IDENTITY);
+        edges.push(EdgeWrapperEnum::new_hold_identity(hd));
+
+        if address != verification_address {
+            // Do not push the same target repeatedly
+            targets.push(Target::Identity(protocol, verification_address.clone()))
+        }
+    }
+
+    targets.push(Target::Identity(Platform::Farcaster, user.username.clone()));
+    Ok((targets, edges))
 }
 
 pub async fn fetch_by_username(

--- a/src/upstream/firefly/mod.rs
+++ b/src/upstream/firefly/mod.rs
@@ -1,0 +1,277 @@
+#[cfg(test)]
+mod tests;
+use crate::config::C;
+use crate::error::Error;
+use crate::tigergraph::edge::{Edge, Hold, Proof, Resolve, Wrapper};
+use crate::tigergraph::edge::{
+    HOLD_CONTRACT, HOLD_IDENTITY, PROOF_EDGE, PROOF_REVERSE_EDGE, RESOLVE, RESOLVE_CONTRACT,
+    REVERSE_RESOLVE, REVERSE_RESOLVE_CONTRACT,
+};
+use crate::tigergraph::upsert::create_identity_to_identity_proof_two_way_binding;
+use crate::tigergraph::vertex::{Contract, Identity};
+use crate::tigergraph::{BatchEdges, EdgeWrapperEnum, UpsertGraph};
+use crate::upstream::{
+    Chain, ContractCategory, DataFetcher, DataSource, DomainNameSystem, Fetcher, Platform,
+    ProofLevel, TargetProcessedList,
+};
+use crate::util::{
+    make_client, make_http_client, naive_now, parse_body, request_with_timeout, timestamp_to_naive,
+};
+
+use async_trait::async_trait;
+use http::uri::InvalidUri;
+use http::StatusCode;
+use hyper::{Body, Method, Request};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use super::Target;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AggregationResponse {
+    pub code: i32,
+    pub msg: Option<String>,
+    data: Option<Vec<AggregationRecord>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AggregationRecord {
+    pub account_id: String,  // Firefly Account ID
+    pub uid: Option<String>, // ID of the identity
+    pub platform: String,    // Platform in [ethereum, farcaster, twitter]
+    pub identity: String,
+    pub data_source: String,  // firefly or admin(manually_added)
+    pub update_time: i64,     // record update time
+    pub display_name: String, // fname
+}
+
+pub struct Firefly {}
+
+#[async_trait]
+impl Fetcher for Firefly {
+    async fn fetch(target: &Target) -> Result<TargetProcessedList, Error> {
+        if !Self::can_fetch(target) {
+            return Ok(vec![]);
+        }
+
+        match target {
+            Target::Identity(platform, identity) => {
+                fetch_connections_by_platform_identity(platform, identity).await
+            }
+            Target::NFT(_, _, _, _) => todo!(),
+        }
+    }
+
+    fn can_fetch(target: &Target) -> bool {
+        target.in_platform_supported(vec![
+            Platform::Ethereum,
+            Platform::Twitter,
+            Platform::Farcaster,
+        ])
+    }
+}
+
+async fn fetch_connections_by_platform_identity(
+    platform: &Platform,
+    identity: &str,
+) -> Result<TargetProcessedList, Error> {
+    let cli = make_http_client();
+    let records = search_records(platform, identity).await?;
+    if records.is_empty() {
+        debug!("Aggregation search result is empty");
+    }
+    let mut next_targets: Vec<Target> = Vec::new();
+    let mut proofs: Vec<EdgeWrapperEnum> = Vec::new();
+
+    for (from_idx, from_v) in records.iter().enumerate() {
+        let mut data_source = DataSource::Firefly;
+        if from_v.data_source == String::from("admin") {
+            data_source = DataSource::ManuallyAdded;
+        }
+        let from_update_naive = timestamp_to_naive(from_v.update_time, 0);
+        let from_platform =
+            Platform::from_str(from_v.platform.as_str()).unwrap_or(Platform::Unknown);
+        if from_platform == Platform::Unknown {
+            continue;
+        }
+        if from_platform != *platform {
+            // Do not push duplicate targets into fetchjob
+            next_targets.push(Target::Identity(from_platform, from_v.identity.clone()))
+        }
+        let from = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: from_platform.clone(),
+            identity: from_v.identity.clone(),
+            uid: from_v.uid.clone(),
+            created_at: from_update_naive,
+            display_name: None,
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+
+        for (to_idx, to_v) in records.iter().enumerate() {
+            if to_idx >= from_idx {
+                continue;
+            }
+            info!("{}, {}", from_idx, to_idx);
+            let to_update_naive = timestamp_to_naive(to_v.update_time, 0);
+            let to_platform =
+                Platform::from_str(to_v.platform.as_str()).unwrap_or(Platform::Unknown);
+            if to_platform == Platform::Unknown {
+                continue;
+            }
+            let to = Identity {
+                uuid: Some(Uuid::new_v4()),
+                platform: to_platform.clone(),
+                identity: to_v.identity.clone(),
+                uid: to_v.uid.clone(),
+                created_at: to_update_naive.clone(),
+                display_name: None,
+                added_at: naive_now(),
+                avatar_url: None,
+                profile_url: None,
+                updated_at: naive_now(),
+                expired_at: None,
+                reverse: Some(false),
+            };
+
+            let proof_forward = Proof {
+                uuid: Uuid::new_v4(),
+                source: data_source,
+                level: ProofLevel::VeryConfident,
+                record_id: Some(from_v.account_id.clone()),
+                created_at: to_update_naive.clone(),
+                updated_at: naive_now(),
+                fetcher: DataFetcher::DataMgrService,
+            };
+
+            let proof_backward = Proof {
+                uuid: Uuid::new_v4(),
+                source: data_source,
+                level: ProofLevel::VeryConfident,
+                record_id: Some(from_v.account_id.clone()),
+                created_at: to_update_naive.clone(),
+                updated_at: naive_now(),
+                fetcher: DataFetcher::DataMgrService,
+            };
+            let hold: Hold = Hold {
+                uuid: Uuid::new_v4(),
+                source: data_source,
+                transaction: None,
+                id: from_v.account_id.clone(),
+                created_at: None,
+                updated_at: naive_now(),
+                fetcher: DataFetcher::DataMgrService,
+                expired_at: None,
+            };
+
+            let resolve: Resolve = Resolve {
+                uuid: Uuid::new_v4(),
+                source: data_source,
+                system: DomainNameSystem::Genome,
+                name: from_v.account_id.clone(),
+                fetcher: DataFetcher::DataMgrService,
+                updated_at: naive_now(),
+            };
+
+            let contract = Contract {
+                uuid: Uuid::new_v4(),
+                category: ContractCategory::GNS,
+                address: ContractCategory::GNS.default_contract_address().unwrap(),
+                chain: Chain::Gnosis,
+                symbol: Some("GNS".to_string()),
+                updated_at: naive_now(),
+            };
+
+            let pf = proof_forward.wrapper(&from, &to, PROOF_EDGE);
+            let pb = proof_backward.wrapper(&to, &from, PROOF_REVERSE_EDGE);
+            let hd = hold.wrapper(&from, &to, HOLD_IDENTITY);
+            let hdc = hold.wrapper(&from, &contract, HOLD_CONTRACT);
+            let rsc = resolve.wrapper(&contract, &to, REVERSE_RESOLVE_CONTRACT);
+
+            proofs.push(EdgeWrapperEnum::new_proof_forward(pf));
+            proofs.push(EdgeWrapperEnum::new_proof_backward(pb));
+            proofs.push(EdgeWrapperEnum::new_hold_identity(hd));
+            // proofs.push(EdgeWrapperEnum::new_hold_contract(hdc));
+            // proofs.push(EdgeWrapperEnum::new_resolve_contract(rsc));
+        }
+    }
+    let json_raw = serde_json::to_string(&proofs).map_err(|err| Error::JSONParseError(err))?;
+    info!("batch insert proofs: {}\n\n", json_raw);
+    let edges: BatchEdges = BatchEdges(proofs);
+    let graph: UpsertGraph = edges.into();
+    let json_raw_2 = serde_json::to_string(&graph).map_err(|err| Error::JSONParseError(err))?;
+    info!("batch insert proofs format: {}", json_raw_2);
+
+    Ok(next_targets)
+}
+
+async fn search_records(
+    platform: &Platform,
+    identity: &str,
+) -> Result<Vec<AggregationRecord>, Error> {
+    let client = make_client();
+    let uri: http::Uri = format!(
+        "{}/aggregation/search?platform={}&identity={}",
+        C.upstream.aggregation_service.url.clone(),
+        platform.to_string(),
+        identity
+    )
+    .parse()
+    .map_err(|_err: InvalidUri| Error::ParamError(format!("Uri format Error {}", _err)))?;
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .map_err(|_err| {
+            Error::ParamError(format!("Aggregation search Build Request Error {}", _err))
+        })?;
+
+    let mut resp = request_with_timeout(&client, req, None)
+        .await
+        .map_err(|err| {
+            Error::ManualHttpClientError(format!(
+                "Aggregation search | error: {:?}",
+                err.to_string()
+            ))
+        })?;
+
+    if !resp.status().is_success() {
+        let err_message = format!("Aggregation search error, statusCode: {}", resp.status());
+        error!(err_message);
+        return Err(Error::General(err_message, resp.status()));
+    }
+
+    let result = match parse_body::<AggregationResponse>(&mut resp).await {
+        Ok(result) => {
+            if result.code != 0 {
+                let err_message = format!(
+                    "Aggregation search error | Code: {:?}, Message: {:?}",
+                    result.code, result.msg
+                );
+                error!(err_message);
+                return Err(Error::General(
+                    err_message,
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                ));
+            }
+            let return_data: Vec<AggregationRecord> = result.data.map_or(vec![], |res| res);
+            debug!("Aggregation search records found {}.", return_data.len(),);
+            return_data
+        }
+        Err(err) => {
+            let err_message = format!("Genome get_address error parse_body error: {:?}", err);
+            error!(err_message);
+            return Err(Error::General(err_message, resp.status()));
+        }
+    };
+
+    Ok(result)
+}

--- a/src/upstream/firefly/tests.rs
+++ b/src/upstream/firefly/tests.rs
@@ -1,0 +1,33 @@
+#[cfg(test)]
+mod tests {
+    use crate::error::Error;
+    use crate::upstream::firefly::{search_records, Firefly};
+    use crate::upstream::{Fetcher, Platform, Target};
+
+    #[tokio::test]
+    async fn test_search_records() -> Result<(), Error> {
+        let _identity = "kins";
+        let _platform = Platform::Farcaster;
+
+        let _identity_1 = "j0hnwang";
+        let _platform_1 = Platform::Twitter;
+
+        let _identity_2 = "0x88a4febb4572cf01967e5ff9b6109dea57168c6d";
+        let _platform_2 = Platform::Ethereum;
+
+        let records = search_records(&_platform_1, _identity_1).await?;
+        println!("records: {:?}", records);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fetch() -> Result<(), Error> {
+        let target = Target::Identity(
+            Platform::Ethereum,
+            "0x61ae970ac67ff4164ebf2fd6f38f630df522e5ef".to_lowercase(),
+        );
+        // let target = Target::Identity(Platform::Farcaster, "kins".to_string());
+        let _ = Firefly::fetch(&target).await?;
+        Ok(())
+    }
+}

--- a/src/upstream/knn3/mod.rs
+++ b/src/upstream/knn3/mod.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::tigergraph::edge::Hold;
 use crate::tigergraph::upsert::create_identity_to_contract_hold_record;
 use crate::tigergraph::vertex::{Contract, Identity};
+use crate::tigergraph::EdgeList;
 use crate::upstream::{
     Chain, ContractCategory, DataFetcher, DataSource, Fetcher, Platform, Target,
     TargetProcessedList,
@@ -61,6 +62,13 @@ impl Fetcher for Knn3 {
             Target::Identity(_, identity) => fetch_ens_by_eth_wallet(identity).await,
             Target::NFT(_, _, _, id) => fetch_eth_wallet_by_ens(id).await,
         }
+    }
+
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+        Ok((vec![], vec![]))
     }
 
     fn can_fetch(_target: &Target) -> bool {

--- a/src/upstream/lens/mod.rs
+++ b/src/upstream/lens/mod.rs
@@ -8,6 +8,7 @@ use crate::tigergraph::upsert::create_identity_domain_resolve_record;
 use crate::tigergraph::upsert::create_identity_domain_reverse_resolve_record;
 use crate::tigergraph::upsert::create_identity_to_identity_hold_record;
 use crate::tigergraph::vertex::Identity;
+use crate::tigergraph::EdgeList;
 use crate::upstream::{
     DataFetcher, DataSource, DomainNameSystem, Fetcher, Platform, Target, TargetProcessedList,
 };
@@ -114,6 +115,13 @@ impl Fetcher for Lens {
             Platform::Lens => fetch_by_lens_profile(target).await,
             _ => Ok(vec![]),
         }
+    }
+
+    async fn batch_fetch(_target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+        Ok((vec![], vec![]))
     }
 
     fn can_fetch(target: &Target) -> bool {

--- a/src/upstream/lensv2/tests.rs
+++ b/src/upstream/lensv2/tests.rs
@@ -26,13 +26,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_by_lens_handle() -> Result<(), Error> {
-        let target = Target::Identity(Platform::Lens, String::from("sujiyan.lens"));
+        let target = Target::Identity(Platform::Lens, String::from("xnownx.lens"));
         let _ = LensV2::fetch(&target).await?;
         let client = make_http_client();
         let found = Identity::find_by_platform_identity(
             &client,
             &Platform::Ethereum,
-            &String::from("0x934B510D4C9103E6a87AEf13b816fb080286D649").to_lowercase(),
+            &String::from("0x88a4FebB4572CF01967e5Ff9B6109dEA57168c6d").to_lowercase(),
         )
         .await?
         .expect("Record not found");

--- a/src/upstream/mod.rs
+++ b/src/upstream/mod.rs
@@ -4,6 +4,7 @@ mod crossbell;
 mod dotbit;
 mod ens_reverse;
 mod farcaster;
+mod firefly;
 mod genome;
 mod keybase;
 mod knn3;
@@ -22,14 +23,14 @@ mod types;
 
 use crate::{
     error::Error,
+    tigergraph::{batch_upsert, EdgeList},
     upstream::{
-        aggregation::Aggregation, crossbell::Crossbell, dotbit::DotBit,
-        ens_reverse::ENSReverseLookup, farcaster::Farcaster, genome::Genome, keybase::Keybase,
-        knn3::Knn3, lensv2::LensV2, proof_client::ProofClient, rss3::Rss3, solana::Solana,
-        space_id::SpaceId, sybil_list::SybilList, the_graph::TheGraph,
-        unstoppable::UnstoppableDomains,
+        crossbell::Crossbell, dotbit::DotBit, ens_reverse::ENSReverseLookup, farcaster::Farcaster,
+        firefly::Firefly, genome::Genome, keybase::Keybase, knn3::Knn3, lensv2::LensV2,
+        proof_client::ProofClient, rss3::Rss3, solana::Solana, space_id::SpaceId,
+        sybil_list::SybilList, the_graph::TheGraph, unstoppable::UnstoppableDomains,
     },
-    util::hashset_append,
+    util::{hashset_append, make_http_client},
 };
 use async_trait::async_trait;
 use futures::{future::join_all, StreamExt};
@@ -54,6 +55,9 @@ pub trait Fetcher {
     /// Fetch data from given source.
     async fn fetch(target: &Target) -> Result<TargetProcessedList, Error>;
 
+    /// Fetch all vertices and edges from given source and return them
+    async fn fetch_and_save(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error>;
+
     /// Determine if this upstream can fetch this target.
     fn can_fetch(target: &Target) -> bool;
 }
@@ -66,9 +70,11 @@ pub trait Fetcher {
 #[async_recursion::async_recursion]
 pub async fn fetch_all(targets: TargetProcessedList, depth: Option<u16>) -> Result<(), Error> {
     let mut round: u16 = 0;
+    let mut up_next: HashSet<Target> = HashSet::new();
+    let mut all_edges: EdgeList = EdgeList::new();
 
     let mut fetching = FETCHING.lock().await;
-    let mut up_next: HashSet<Target> = HashSet::from_iter(
+    up_next.extend(
         targets
             .clone()
             .into_iter()
@@ -76,19 +82,14 @@ pub async fn fetch_all(targets: TargetProcessedList, depth: Option<u16>) -> Resu
     );
     up_next.iter().for_each(|target| {
         fetching.insert(target.clone());
-        ()
     });
     drop(fetching);
+
     let mut processed: HashSet<Target> = HashSet::new();
 
-    // FETCHING.lock().await.insert(initial_target.clone());
-    // queues of this session.
-    // let mut up_next = HashSet::from([initial_target.clone()]);
-    // let mut processed: HashSet<Target> = HashSet::new();
-
-    while up_next.len() > 0 {
+    while !up_next.is_empty() {
         round += 1;
-        let result = fetch_many(
+        let (next_targets, edges) = fetch_many(
             up_next
                 .clone()
                 .into_iter()
@@ -97,23 +98,30 @@ pub async fn fetch_all(targets: TargetProcessedList, depth: Option<u16>) -> Resu
             Some(round),
         )
         .await?;
+
+        hashset_append(&mut processed, up_next.into_iter().collect());
+        up_next = HashSet::from_iter(next_targets.into_iter());
+
+        all_edges.extend(edges);
+
         if depth.is_some() && depth.unwrap() <= round {
             // Fork as background job to continue fetching.
             tokio::spawn(fetch_all(up_next.into_iter().collect(), None));
             break;
         }
-
-        // Add previous up_next into processed, and replace with new up_next
-        hashset_append(&mut processed, up_next.into_iter().collect());
-        up_next = HashSet::from_iter(result.into_iter());
     }
 
     let mut fetching = FETCHING.lock().await;
     targets.iter().for_each(|target| {
         fetching.remove(&target);
-        ()
     });
     drop(fetching);
+
+    // Upsert all edges after fetching completes
+    if !all_edges.is_empty() {
+        let cli = make_http_client();
+        batch_upsert(&cli, all_edges).await?;
+    }
 
     event!(
         Level::INFO,
@@ -122,60 +130,159 @@ pub async fn fetch_all(targets: TargetProcessedList, depth: Option<u16>) -> Resu
         processed = processed.len(),
         "Fetch completed."
     );
+
     Ok(())
+
+    // let mut round: u16 = 0;
+
+    // let mut fetching = FETCHING.lock().await;
+    // let mut up_next: HashSet<Target> = HashSet::from_iter(
+    //     targets
+    //         .clone()
+    //         .into_iter()
+    //         .filter(|target| !fetching.contains(target)),
+    // );
+    // up_next.iter().for_each(|target| {
+    //     fetching.insert(target.clone());
+    //     ()
+    // });
+    // drop(fetching);
+    // let mut processed: HashSet<Target> = HashSet::new();
+
+    // // FETCHING.lock().await.insert(initial_target.clone());
+    // // queues of this session.
+    // // let mut up_next = HashSet::from([initial_target.clone()]);
+    // // let mut processed: HashSet<Target> = HashSet::new();
+
+    // while up_next.len() > 0 {
+    //     round += 1;
+    //     let result = fetch_many(
+    //         up_next
+    //             .clone()
+    //             .into_iter()
+    //             .filter(|target| !processed.contains(target))
+    //             .collect(),
+    //         Some(round),
+    //     )
+    //     .await?;
+    //     if depth.is_some() && depth.unwrap() <= round {
+    //         // Fork as background job to continue fetching.
+    //         tokio::spawn(fetch_all(up_next.into_iter().collect(), None));
+    //         break;
+    //     }
+
+    //     // Add previous up_next into processed, and replace with new up_next
+    //     hashset_append(&mut processed, up_next.into_iter().collect());
+    //     up_next = HashSet::from_iter(result.into_iter());
+    // }
+
+    // let mut fetching = FETCHING.lock().await;
+    // targets.iter().for_each(|target| {
+    //     fetching.remove(&target);
+    //     ()
+    // });
+    // drop(fetching);
+
+    // event!(
+    //     Level::INFO,
+    //     round,
+    //     ?depth,
+    //     processed = processed.len(),
+    //     "Fetch completed."
+    // );
+    // Ok(())
 }
 
 /// Fetch targets in parallel of 5.
 /// `round` is only for log purpose.
-pub async fn fetch_many(targets: Vec<Target>, round: Option<u16>) -> Result<Vec<Target>, Error> {
+pub async fn fetch_many(
+    targets: Vec<Target>,
+    round: Option<u16>,
+) -> Result<(TargetProcessedList, EdgeList), Error> {
     const CONCURRENT: usize = 5;
-    let futures: Vec<_> = targets.iter().map(|target| fetch_one(target)).collect();
+    let futures: Vec<_> = targets
+        .iter()
+        .map(|target| fetch_one_and_save(target))
+        .collect();
     let futures_stream = futures::stream::iter(futures).buffer_unordered(CONCURRENT);
 
-    let mut result: TargetProcessedList = futures_stream
-        .collect::<Vec<Result<Vec<Target>, Error>>>()
-        .await
-        .into_iter()
-        .flat_map(|handle_result| -> Vec<Target> {
-            match handle_result {
-                Ok(result) => {
-                    event!(
-                        Level::DEBUG,
-                        ?round,
-                        fetched_length = result.len(),
-                        "Round completed."
-                    );
-                    result
+    let (mut all_targets, all_edges) = futures_stream
+        .fold(
+            (TargetProcessedList::new(), EdgeList::new()),
+            |(mut all_targets, mut all_edges), handle_result| async move {
+                match handle_result {
+                    Ok((targets, edges)) => {
+                        event!(
+                            Level::DEBUG,
+                            ?round,
+                            fetched_length = targets.len(),
+                            "Round completed."
+                        );
+                        all_targets.extend(targets);
+                        all_edges.extend(edges);
+                    }
+                    Err(err) => {
+                        event!(Level::WARN, ?round, %err, "Error happened in fetching task");
+                    }
                 }
-                Err(err) => {
-                    event!(Level::WARN, ?round, %err, "Error happened in fetching task");
-                    vec![]
-                }
-            }
-        })
-        .collect();
-    result.dedup();
-    Ok(result)
+                (all_targets, all_edges)
+            },
+        )
+        .await;
+    all_targets.dedup();
+    // event!(Level::INFO, "fetch_many all_targets {:?}", all_targets);
+
+    Ok((all_targets, all_edges))
+
+    // const CONCURRENT: usize = 5;
+    // let futures: Vec<_> = targets.iter().map(|target| fetch_one(target)).collect();
+    // let futures_stream = futures::stream::iter(futures).buffer_unordered(CONCURRENT);
+
+    // let mut result: TargetProcessedList = futures_stream
+    //     .collect::<Vec<Result<Vec<Target>, Error>>>()
+    //     .await
+    //     .into_iter()
+    //     .flat_map(|handle_result| -> Vec<Target> {
+    //         match handle_result {
+    //             Ok(result) => {
+    //                 event!(
+    //                     Level::DEBUG,
+    //                     ?round,
+    //                     fetched_length = result.len(),
+    //                     "Round completed."
+    //                 );
+    //                 result
+    //             }
+    //             Err(err) => {
+    //                 event!(Level::WARN, ?round, %err, "Error happened in fetching task");
+    //                 vec![]
+    //             }
+    //         }
+    //     })
+    //     .collect();
+    // result.dedup();
+    // Ok(result)
 }
+
 /// Find one (platform, identity) pair in all upstreams.
 /// Returns amount of identities just fetched for next iter.
 pub async fn fetch_one(target: &Target) -> Result<Vec<Target>, Error> {
     let mut up_next: TargetProcessedList = join_all(vec![
+        TheGraph::fetch(target),
+        ENSReverseLookup::fetch(target),
         Farcaster::fetch(target),
         LensV2::fetch(target),
-        Aggregation::fetch(target),
-        SybilList::fetch(target),
-        Keybase::fetch(target),
         ProofClient::fetch(target),
+        Keybase::fetch(target),
+        // Firefly::fetch(target),
+        SybilList::fetch(target),
         Rss3::fetch(target),
         Knn3::fetch(target),
-        ENSReverseLookup::fetch(target),
         DotBit::fetch(target),
         UnstoppableDomains::fetch(target),
         SpaceId::fetch(target),
         Genome::fetch(target),
         Crossbell::fetch(target),
-        TheGraph::fetch(target),
         Solana::fetch(target),
     ])
     .await
@@ -205,6 +312,49 @@ pub async fn fetch_one(target: &Target) -> Result<Vec<Target>, Error> {
         .collect();
 
     Ok(up_next)
+}
+
+pub async fn fetch_one_and_save(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let mut up_next = TargetProcessedList::new();
+    let mut all_edges = EdgeList::new();
+
+    let _ = join_all(vec![Firefly::fetch_and_save(target)])
+        .await
+        .into_iter()
+        .for_each(|res| {
+            if let Ok((next_targets, edges)) = res {
+                up_next.extend(next_targets);
+                all_edges.extend(edges);
+            } else if let Err(err) = res {
+                warn!(
+                    "Error happened when fetching and saving {}: {}",
+                    target, err
+                );
+                // Don't break the procedure, continue with other results
+            }
+        });
+
+    // let json_raw_2 = serde_json::to_string(&all_edges).map_err(|err| Error::JSONParseError(err))?;
+    // info!("BatchEdges format: {}", json_raw_2);
+    // let cli = make_http_client();
+    // batch_upsert(&cli, all_edges).await?;
+
+    up_next.dedup();
+    // Filter zero address
+    up_next = up_next
+        .into_iter()
+        .filter(|target| match target {
+            Target::Identity(Platform::Ethereum, address) => {
+                // Filter zero address (without last 4 digits)
+                return !address.starts_with("0x000000000000000000000000000000000000");
+            }
+            Target::Identity(_, _) => true,
+            Target::NFT(_, _, _, _) => true,
+        })
+        .collect();
+
+    // event!(Level::INFO, "fetch_one_and_save up_next {:?}", up_next);
+    Ok((up_next, all_edges))
 }
 
 /// Prefetch all prefetchable upstreams, e.g. SybilList.

--- a/src/upstream/opensea/mod.rs
+++ b/src/upstream/opensea/mod.rs
@@ -1,0 +1,233 @@
+#[cfg(test)]
+mod tests;
+use crate::config::C;
+use crate::error::Error;
+use crate::tigergraph::edge::{HyperEdge, Proof, Wrapper};
+use crate::tigergraph::edge::{HYPER_EDGE, PROOF_EDGE, PROOF_REVERSE_EDGE};
+use crate::tigergraph::vertex::{IdentitiesGraph, Identity};
+use crate::tigergraph::{EdgeList, EdgeWrapperEnum};
+use crate::upstream::{
+    DataFetcher, DataSource, Fetcher, Platform, ProofLevel, TargetProcessedList,
+};
+use crate::util::{make_client, naive_now, parse_body, request_with_timeout};
+
+use async_trait::async_trait;
+use http::uri::InvalidUri;
+use http::StatusCode;
+use hyper::{Body, Method, Request};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error};
+use uuid::Uuid;
+
+use super::Target;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DataResponse {
+    pub code: i32,
+    pub msg: Option<String>,
+    pub data: Option<Vec<SnsRecord>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SnsRecord {
+    pub address: String,      // evm address
+    pub sns_platform: String, // Platform in [twitter, instagram]
+    pub sns_handle: String,
+    pub is_verified: bool, // is verified or not
+}
+
+pub struct OpenSea {}
+
+#[async_trait]
+impl Fetcher for OpenSea {
+    async fn fetch(target: &Target) -> Result<TargetProcessedList, Error> {
+        if !Self::can_fetch(target) {
+            return Ok(vec![]);
+        }
+        Ok(vec![])
+    }
+
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        match target {
+            Target::Identity(platform, identity) => {
+                batch_fetch_connections(platform, identity).await
+            }
+            Target::NFT(_, _, _, _) => todo!(),
+        }
+    }
+
+    fn can_fetch(target: &Target) -> bool {
+        target.in_platform_supported(vec![
+            Platform::Ethereum,
+            Platform::Twitter,
+            Platform::Instagram,
+        ])
+    }
+}
+
+async fn batch_fetch_connections(
+    platform: &Platform,
+    identity: &str,
+) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let records = search_opensea_account(platform, identity).await?;
+    if records.is_empty() {
+        debug!("OpenSea search result is empty");
+        return Ok((vec![], vec![]));
+    }
+    debug!("OpenSea search records found {}.", records.len(),);
+    let mut next_targets: Vec<Target> = Vec::new();
+    let mut edges: Vec<EdgeWrapperEnum> = Vec::new();
+    let hv = IdentitiesGraph::default();
+
+    for record in records.iter() {
+        let sns_platform: Platform = record.sns_platform.parse()?;
+        let sns_handle = record.sns_handle.clone();
+        let address = record.address.clone();
+        if !record.is_verified {
+            debug!(
+                "OpenSea search address({}) => {}={} not verified.",
+                address, sns_platform, sns_handle
+            );
+            continue;
+        }
+
+        if sns_platform == Platform::Unknown {
+            continue;
+        }
+
+        if sns_platform != *platform {
+            // Do not push duplicate targets into fetchjob
+            next_targets.push(Target::Identity(sns_platform, sns_handle.clone()))
+        }
+
+        let from = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Ethereum,
+            identity: address,
+            uid: None,
+            created_at: None,
+            display_name: None,
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+
+        let to = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: sns_platform,
+            identity: sns_handle.clone(),
+            uid: None,
+            created_at: None,
+            display_name: Some(sns_handle.clone()),
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+
+        // add identity connected to hyper vertex
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &from, HYPER_EDGE),
+        ));
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &to, HYPER_EDGE),
+        ));
+
+        let proof_forward = Proof {
+            uuid: Uuid::new_v4(),
+            source: DataSource::OpenSea,
+            level: ProofLevel::Confident,
+            record_id: None,
+            created_at: None,
+            updated_at: naive_now(),
+            fetcher: DataFetcher::DataMgrService,
+        };
+
+        let proof_backward = Proof {
+            uuid: Uuid::new_v4(),
+            source: DataSource::OpenSea,
+            level: ProofLevel::Confident,
+            record_id: None,
+            created_at: None,
+            updated_at: naive_now(),
+            fetcher: DataFetcher::DataMgrService,
+        };
+
+        let pf = proof_forward.wrapper(&from, &to, PROOF_EDGE);
+        let pb = proof_backward.wrapper(&to, &from, PROOF_REVERSE_EDGE);
+
+        edges.push(EdgeWrapperEnum::new_proof_forward(pf));
+        edges.push(EdgeWrapperEnum::new_proof_backward(pb));
+    }
+
+    Ok((next_targets, edges))
+}
+
+async fn search_opensea_account(
+    platform: &Platform,
+    identity: &str,
+) -> Result<Vec<SnsRecord>, Error> {
+    let client = make_client();
+    let uri: http::Uri = format!(
+        "{}/aggregation/opensea_account?platform={}&identity={}",
+        C.upstream.aggregation_service.url.clone(),
+        platform.to_string(),
+        identity
+    )
+    .parse()
+    .map_err(|_err: InvalidUri| Error::ParamError(format!("OpenSea Uri format Error {}", _err)))?;
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .body(Body::empty())
+        .map_err(|_err| {
+            Error::ParamError(format!("OpenSea search Build Request Error {}", _err))
+        })?;
+
+    let mut resp = request_with_timeout(&client, req, None)
+        .await
+        .map_err(|err| {
+            Error::ManualHttpClientError(format!("OpenSea search | error: {:?}", err.to_string()))
+        })?;
+
+    if !resp.status().is_success() {
+        let err_message = format!("OpenSea search error, statusCode: {}", resp.status());
+        error!(err_message);
+        return Err(Error::General(err_message, resp.status()));
+    }
+
+    let result = match parse_body::<DataResponse>(&mut resp).await {
+        Ok(result) => {
+            if result.code != 0 {
+                let err_message = format!(
+                    "OpenSea search error | Code: {:?}, Message: {:?}",
+                    result.code, result.msg
+                );
+                error!(err_message);
+                return Err(Error::General(
+                    err_message,
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                ));
+            }
+            let return_data: Vec<SnsRecord> = result.data.map_or(vec![], |res| res);
+            return_data
+        }
+        Err(err) => {
+            let err_message = format!("OpenSea search parse_body error: {:?}", err);
+            error!(err_message);
+            return Err(Error::General(err_message, resp.status()));
+        }
+    };
+
+    Ok(result)
+}

--- a/src/upstream/proof_client/mod.rs
+++ b/src/upstream/proof_client/mod.rs
@@ -4,9 +4,12 @@ mod tests;
 
 use crate::config::C;
 use crate::error::Error;
-use crate::tigergraph::edge::Proof;
+use crate::tigergraph::edge::{
+    HyperEdge, Proof, Wrapper, HYPER_EDGE, PROOF_EDGE, PROOF_REVERSE_EDGE,
+};
 use crate::tigergraph::upsert::create_identity_to_identity_proof_two_way_binding;
-use crate::tigergraph::vertex::Identity;
+use crate::tigergraph::vertex::{IdentitiesGraph, Identity};
+use crate::tigergraph::{EdgeList, EdgeWrapperEnum};
 use crate::upstream::{DataSource, Fetcher, Platform, ProofLevel, Target, TargetProcessedList};
 use crate::util::make_http_client;
 use crate::util::{make_client, naive_now, parse_body, request_with_timeout, timestamp_to_naive};
@@ -73,6 +76,19 @@ impl Fetcher for ProofClient {
         }
     }
 
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        match target {
+            Target::Identity(platform, identity) => {
+                batch_fetch_connections(platform, identity).await
+            }
+            Target::NFT(_, _, _, _) => todo!(),
+        }
+    }
+
     fn can_fetch(target: &Target) -> bool {
         target.in_platform_supported(vec![
             Platform::Ethereum,
@@ -82,6 +98,158 @@ impl Fetcher for ProofClient {
             Platform::Dotbit,
         ])
     }
+}
+
+#[tracing::instrument(level = "trace", fields(platform = %platform, identity = %identity))]
+async fn batch_fetch_connections(
+    platform: &Platform,
+    identity: &str,
+) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let client = make_client();
+
+    let uri: http::Uri = format!(
+        "{}/v1/proof?exact=true&platform={}&identity={}",
+        C.upstream.proof_service.url, platform, identity
+    )
+    .parse()
+    .map_err(|_err| Error::ParamError("Uri format Error".to_string()))?;
+
+    let req = hyper::Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("x-api-key", C.upstream.proof_service.api_key.clone())
+        .body(Body::empty())
+        .map_err(|_err| Error::ParamError(format!("Proof Service Build Request Error {}", _err)))?;
+
+    let mut resp = request_with_timeout(&client, req, None)
+        .await
+        .map_err(|err| {
+            Error::ManualHttpClientError(format!(
+                "Proof Service fetch | error: {:?}",
+                err.to_string()
+            ))
+        })?;
+
+    if !resp.status().is_success() {
+        let body: ErrorResponse = parse_body(&mut resp).await?;
+        error!("Proof Service fetch error, status {}", resp.status());
+        return Err(Error::General(
+            format!("Proof Result Get Error: {}", body.message),
+            resp.status(),
+        ));
+    }
+
+    let query_result: ProofQueryResponse = parse_body(&mut resp).await?;
+    if query_result.pagination.total == 0 {
+        error!("Proof Service ({}, {}) NoResult", platform, identity);
+        return Ok((vec![], vec![]));
+    }
+
+    debug!(length = query_result.ids.len(), "Found.");
+    if query_result.ids.len() == 0 {
+        error!("Proof Service ({}, {}) NoResult", platform, identity);
+        return Ok((vec![], vec![]));
+    }
+
+    let mut next_targets = TargetProcessedList::new();
+    let mut edges = EdgeList::new();
+    let hv = IdentitiesGraph::default();
+
+    for id in query_result.ids {
+        let ProofPersona { avatar, proofs } = id;
+
+        for p in proofs.into_iter() {
+            if p.is_valid == false {
+                continue;
+            }
+            let from: Identity = Identity {
+                uuid: Some(Uuid::new_v4()),
+                platform: Platform::NextID,
+                identity: avatar.clone(),
+                uid: None,
+                created_at: timestamp_to_naive(p.created_at.to_string().parse::<i64>().unwrap(), 0),
+                display_name: Some(avatar.clone()),
+                added_at: naive_now(),
+                avatar_url: None,
+                profile_url: None,
+                updated_at: naive_now(),
+                expired_at: None,
+                reverse: Some(false),
+            };
+
+            let to_platform = Platform::from_str(p.platform.as_str()).unwrap_or(Platform::Unknown);
+            if to_platform == Platform::Unknown {
+                event!(
+                    Level::WARN,
+                    ?platform,
+                    identity,
+                    platform = p.platform,
+                    "found unknown connected platform",
+                );
+                continue;
+            }
+
+            let to: Identity = Identity {
+                uuid: Some(Uuid::new_v4()),
+                platform: to_platform,
+                identity: p.identity.to_string().to_lowercase(),
+                uid: None,
+                created_at: timestamp_to_naive(p.created_at.to_string().parse().unwrap(), 0),
+                // Don't use ETH's wallet as display_name, use ENS reversed lookup instead.
+                display_name: if to_platform == Platform::Ethereum {
+                    None
+                } else {
+                    Some(p.identity.clone())
+                },
+                added_at: naive_now(),
+                avatar_url: None,
+                profile_url: None,
+                updated_at: naive_now(),
+                expired_at: None,
+                reverse: Some(false),
+            };
+
+            let proof_forward: Proof = Proof {
+                uuid: Uuid::new_v4(),
+                source: DataSource::NextID,
+                level: ProofLevel::VeryConfident,
+                record_id: None,
+                created_at: timestamp_to_naive(p.created_at.to_string().parse().unwrap(), 0),
+                updated_at: naive_now(),
+                fetcher: DataFetcher::RelationService,
+            };
+
+            let proof_backward: Proof = Proof {
+                uuid: Uuid::new_v4(),
+                source: DataSource::NextID,
+                level: ProofLevel::VeryConfident,
+                record_id: None,
+                created_at: timestamp_to_naive(p.created_at.to_string().parse().unwrap(), 0),
+                updated_at: naive_now(),
+                fetcher: DataFetcher::RelationService,
+            };
+
+            // add identity connected to hyper vertex
+            edges.push(EdgeWrapperEnum::new_hyper_edge(
+                HyperEdge {}.wrapper(&hv, &from, HYPER_EDGE),
+            ));
+            edges.push(EdgeWrapperEnum::new_hyper_edge(
+                HyperEdge {}.wrapper(&hv, &to, HYPER_EDGE),
+            ));
+
+            // two-way binding
+            let pf = proof_forward.wrapper(&from, &to, PROOF_EDGE);
+            let pb = proof_backward.wrapper(&to, &from, PROOF_REVERSE_EDGE);
+
+            edges.push(EdgeWrapperEnum::new_proof_forward(pf));
+            edges.push(EdgeWrapperEnum::new_proof_backward(pb));
+
+            next_targets.push(Target::Identity(to_platform, p.identity));
+        }
+    }
+    next_targets.dedup();
+    event!(Level::TRACE, "Next target count: {:?}", next_targets.len());
+    Ok((next_targets, edges))
 }
 
 #[tracing::instrument(level = "trace", fields(platform = %platform, identity = %identity))]

--- a/src/upstream/rss3/mod.rs
+++ b/src/upstream/rss3/mod.rs
@@ -3,9 +3,10 @@ mod tests;
 
 use crate::config::C;
 use crate::error::Error;
-use crate::tigergraph::edge::Hold;
+use crate::tigergraph::edge::{Hold, HyperEdge, Wrapper, HOLD_CONTRACT, HYPER_EDGE};
 use crate::tigergraph::upsert::create_identity_to_contract_hold_record;
-use crate::tigergraph::vertex::{Contract, Identity};
+use crate::tigergraph::vertex::{Contract, IdentitiesGraph, Identity};
+use crate::tigergraph::{EdgeList, EdgeWrapperEnum};
 use crate::upstream::{
     Chain, ContractCategory, DataSource, Fetcher, Platform, Target, TargetProcessedList,
 };
@@ -92,9 +93,193 @@ impl Fetcher for Rss3 {
         }
     }
 
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        match target.platform()? {
+            Platform::Ethereum => batch_fetch_nfts(target).await,
+            _ => Ok((vec![], vec![])),
+        }
+    }
+
     fn can_fetch(target: &Target) -> bool {
         target.in_platform_supported(vec![Platform::Ethereum])
     }
+}
+
+async fn batch_fetch_nfts(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let client = make_client();
+    let address = target.identity()?.to_lowercase();
+    let mut cursor = String::from("");
+
+    let mut next_targets = TargetProcessedList::new();
+    let mut edges = EdgeList::new();
+    let hv = IdentitiesGraph::default();
+
+    loop {
+        let uri: http::Uri;
+        if cursor.len() == 0 {
+            uri = format!(
+                "{}/{}?tag=collectible&include_poap=true&refresh=true",
+                C.upstream.rss3_service.url, address
+            )
+            .parse()
+            .map_err(|_err: InvalidUri| Error::ParamError(format!("Uri format Error {}", _err)))?;
+        } else {
+            uri = format!(
+                "{}/{}?tag=collectible&include_poap=true&refresh=true&cursor={}",
+                C.upstream.rss3_service.url, address, cursor
+            )
+            .parse()
+            .map_err(|_err: InvalidUri| Error::ParamError(format!("Uri format Error {}", _err)))?;
+        }
+
+        let req = hyper::Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .body(Body::empty())
+            .map_err(|_err| Error::ParamError(format!("Rss3 Build Request Error {}", _err)))?;
+
+        let mut resp = request_with_timeout(&client, req, None)
+            .await
+            .map_err(|err| {
+                Error::ManualHttpClientError(format!(
+                    "Rss3 fetch fetch | error: {:?}",
+                    err.to_string()
+                ))
+            })?;
+
+        let body: Rss3Response = parse_body(&mut resp).await?;
+        if body.total == 0 {
+            info!("Rss3 Response result is empty");
+            // break;
+        }
+
+        let result: Vec<ResultItem> = body
+            .result
+            .into_iter()
+            .filter(|p| p.owner == address)
+            .collect();
+
+        for p in result.into_iter() {
+            if p.actions.len() == 0 {
+                continue;
+            }
+
+            let found = p
+                .actions
+                .iter()
+                // collectible (transfer, mint, burn) share the same UMS, but approve/revoke not.
+                // we need to record is the `hold` relation, so burn is excluded
+                .filter(|a| {
+                    (a.tag_type == "transfer" && p.tag_type == "transfer")
+                        || (a.tag_type == "mint" && p.tag_type == "mint")
+                })
+                .find(|a| (p.tag == "collectible" && a.tag == "collectible"));
+
+            if found.is_none() {
+                continue;
+            }
+            let real_action = found.unwrap();
+
+            if real_action.metadata.symbol.is_none()
+                || real_action.metadata.symbol.as_ref().unwrap() == &String::from("ENS")
+            {
+                continue;
+            }
+
+            let mut nft_category = ContractCategory::Unknown;
+            let standard = real_action.metadata.standard.clone();
+            if let Some(standard) = standard {
+                if standard == "ERC-721".to_string() {
+                    nft_category = ContractCategory::ERC721;
+                } else if standard == "ERC-1155".to_string() {
+                    nft_category = ContractCategory::ERC1155;
+                }
+            }
+            if real_action.tag_type == "poap".to_string() {
+                nft_category = ContractCategory::POAP;
+            }
+
+            let created_at_naive = match p.timestamp.as_ref() {
+                "" => None,
+                timestamp => match utc_to_naive(timestamp.to_string()) {
+                    Ok(naive_dt) => Some(naive_dt),
+                    Err(_) => None, // You may want to handle this error differently
+                },
+            };
+
+            let from: Identity = Identity {
+                uuid: Some(Uuid::new_v4()),
+                platform: Platform::Ethereum,
+                identity: p.owner.to_lowercase(),
+                uid: None,
+                created_at: created_at_naive,
+                // Don't use ETH's wallet as display_name, use ENS reversed lookup instead.
+                display_name: None,
+                added_at: naive_now(),
+                avatar_url: None,
+                profile_url: None,
+                updated_at: naive_now(),
+                expired_at: None,
+                reverse: Some(false),
+            };
+
+            let chain = Chain::from_str(p.network.as_str()).unwrap_or_default();
+            if chain == Chain::Unknown {
+                error!("Rss3 Fetch data | Unknown Chain, original data: {:?}", p);
+                continue;
+            }
+            let contract_addr = real_action
+                .metadata
+                .contract_address
+                .as_ref()
+                .unwrap()
+                .to_lowercase();
+            let nft_id = real_action.metadata.id.as_ref().unwrap();
+
+            let to: Contract = Contract {
+                uuid: Uuid::new_v4(),
+                category: nft_category,
+                address: contract_addr.clone(),
+                chain,
+                symbol: Some(real_action.metadata.symbol.as_ref().unwrap().clone()),
+                updated_at: naive_now(),
+            };
+
+            let hold: Hold = Hold {
+                uuid: Uuid::new_v4(),
+                source: DataSource::Rss3,
+                transaction: Some(p.hash),
+                id: nft_id.clone(),
+                created_at: created_at_naive,
+                updated_at: naive_now(),
+                fetcher: DataFetcher::RelationService,
+                expired_at: None,
+            };
+
+            edges.push(EdgeWrapperEnum::new_hyper_edge(
+                HyperEdge {}.wrapper(&hv, &from, HYPER_EDGE),
+            ));
+            let hdc = hold.wrapper(&from, &to, HOLD_CONTRACT);
+            edges.push(EdgeWrapperEnum::new_hold_contract(hdc));
+
+            next_targets.push(Target::NFT(
+                chain,
+                nft_category,
+                contract_addr.clone(),
+                nft_id.clone(),
+            ));
+        }
+        if body.cursor.is_none() || body.total < PAGE_LIMIT {
+            break;
+        } else {
+            cursor = body.cursor.unwrap();
+        }
+    }
+    Ok((next_targets, edges))
 }
 
 async fn fetch_nfts_by_account(

--- a/src/upstream/sybil_list/mod.rs
+++ b/src/upstream/sybil_list/mod.rs
@@ -7,6 +7,7 @@ use crate::error::Error;
 use crate::tigergraph::edge::Proof;
 use crate::tigergraph::upsert::create_identity_to_identity_proof_two_way_binding;
 use crate::tigergraph::vertex::Identity;
+use crate::tigergraph::EdgeList;
 use crate::upstream::{DataSource, Fetcher, Platform, ProofLevel, TargetProcessedList};
 use crate::util::make_http_client;
 use crate::util::{make_client, naive_now, parse_body, request_with_timeout, timestamp_to_naive};
@@ -185,6 +186,15 @@ impl Fetcher for SybilList {
                 Ok(vec![])
             }
         }
+    }
+
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        // TODO: prefetch: move this logic to `data_process` module as a scheduled asynchronous fetch
+        Ok((vec![], vec![]))
     }
 
     fn can_fetch(target: &Target) -> bool {

--- a/src/upstream/tests.rs
+++ b/src/upstream/tests.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
-use crate::upstream::{fetch_all, fetch_one, Chain, ContractCategory, Platform, Target};
+use crate::upstream::{
+    batch_fetch_upstream, fetch_all, fetch_one, Chain, ContractCategory, Platform, Target,
+};
 
 #[tokio::test]
 async fn test_fetch_one_result() -> Result<(), Error> {
@@ -10,15 +12,69 @@ async fn test_fetch_one_result() -> Result<(), Error> {
 }
 
 #[tokio::test]
+async fn test_batch_fetch_upstream() -> Result<(), Error> {
+    let target = Target::Identity(Platform::Dotbit, "threebody.bit".into());
+
+    let result = batch_fetch_upstream(&target).await?;
+    println!("{:?}", result);
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_fetch_all() -> Result<(), Error> {
+    // fetch_all(
+    //     vec![Target::Identity(
+    //         Platform::Ethereum,
+    //         "0x0da0ee86269797618032e56a69b1aad095c581fc".into(),
+    //     )],
+    //     Some(5),
+    // )
+    // .await?;
+    // fetch_all(
+    //     vec![Target::Identity(
+    //         Platform::Ethereum,
+    //         "0x934b510d4c9103e6a87aef13b816fb080286d649".into(),
+    //     )],
+    //     Some(5),
+    // )
+    // .await?;
+
+    // fetch_all(
+    //     vec![Target::NFT(
+    //         Chain::Ethereum,
+    //         ContractCategory::ENS,
+    //         ContractCategory::ENS.default_contract_address().unwrap(),
+    //         "niconico.eth".to_string(),
+    //     )],
+    //     Some(5),
+    // )
+    // .await?;
+
     fetch_all(
-        vec![Target::Identity(
-            Platform::Ethereum,
-            "0x934b510d4c9103e6a87aef13b816fb080286d649".into(),
+        vec![Target::NFT(
+            Chain::Ethereum,
+            ContractCategory::ENS,
+            ContractCategory::ENS.default_contract_address().unwrap(),
+            "vitalik.eth".to_string(),
         )],
         Some(5),
     )
     .await?;
+
+    // fetch_all(
+    //     vec![Target::Identity(Platform::CKB, "ckb1qzfhdsa4syv599s2s3nfrctwga70g0tu07n9gpnun9ydlngf5vsnwqggq7v6mzt3n8wv9y2n6h9z429ta0auek7v05yq0xdd39cenhxzj9fatj324z47h77vm0x869nu03m".into())],
+    //     Some(5),
+    // )
+    // .await?;
+
+    // fetch_all(
+    //     vec![Target::Identity(
+    //         Platform::Ethereum,
+    //         "0x6d910bea79aaf318e7170c6fb8318d9c466b2164".into(),
+    //     )],
+    //     Some(5),
+    // )
+    // .await?;
 
     Ok(())
 }

--- a/src/upstream/the_graph/mod.rs
+++ b/src/upstream/the_graph/mod.rs
@@ -3,12 +3,16 @@ mod tests;
 
 use crate::config::C;
 use crate::error::Error;
-use crate::tigergraph::edge::{Hold, Resolve};
+use crate::tigergraph::edge::{
+    Hold, HyperEdge, Resolve, Wrapper, HOLD_CONTRACT, HOLD_IDENTITY, HYPER_EDGE, RESOLVE,
+    RESOLVE_CONTRACT,
+};
 use crate::tigergraph::upsert::create_contract_to_identity_resolve_record;
 use crate::tigergraph::upsert::create_identity_domain_resolve_record;
 use crate::tigergraph::upsert::create_identity_to_contract_hold_record;
 use crate::tigergraph::upsert::{create_ens_identity_ownership, create_ens_identity_resolve};
-use crate::tigergraph::vertex::{Contract, Identity};
+use crate::tigergraph::vertex::{Contract, IdentitiesGraph, Identity};
+use crate::tigergraph::{EdgeList, EdgeWrapperEnum};
 use crate::upstream::{
     Chain, ContractCategory, DataFetcher, DataSource, DomainNameSystem, Fetcher, Platform, Target,
     TargetProcessedList,
@@ -179,6 +183,14 @@ impl Fetcher for TheGraph {
         perform_fetch(target).await
     }
 
+    async fn batch_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+        if !Self::can_fetch(target) {
+            return Ok((vec![], vec![]));
+        }
+
+        batch_perform_fetch(target).await
+    }
+
     fn can_fetch(target: &Target) -> bool {
         target.in_platform_supported(vec![Platform::Ethereum])
             || target.in_nft_supported(vec![ContractCategory::ENS], vec![Chain::Ethereum])
@@ -255,6 +267,171 @@ async fn fetch_domains(target: &Target) -> Result<Vec<Domain>, Error> {
         }
     }
     Ok(merged_domains)
+}
+
+async fn batch_perform_fetch(target: &Target) -> Result<(TargetProcessedList, EdgeList), Error> {
+    let merged_domains = fetch_domains(target).await?;
+    if merged_domains.is_empty() {
+        info!(?target, "TheGraph: No result");
+        return Ok((vec![], vec![]));
+    }
+
+    let platform = match target {
+        Target::Identity(_platform, _identity) => *_platform,
+        Target::NFT(_chain, _category, _contract_addr, _ens_name) => Platform::ENS,
+    };
+
+    let mut next_targets: TargetProcessedList = vec![];
+    let mut edges = EdgeList::new();
+    let hv = IdentitiesGraph::default();
+
+    for domain in merged_domains.into_iter() {
+        let creation_tx = domain
+            .events
+            .first()
+            .map(|event| event.transaction_id.clone());
+        let ens_created_at = parse_timestamp(&domain.created_at).ok();
+        let ens_expired_at = match &domain.registration {
+            Some(registration) => parse_timestamp(&registration.expiry_date).ok(),
+            None => None,
+        };
+
+        let owner = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::Ethereum,
+            identity: domain.owner.id.clone(),
+            uid: None,
+            created_at: None,
+            display_name: None,
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: None,
+            reverse: Some(false),
+        };
+        let ens_domain: Identity = Identity {
+            uuid: Some(Uuid::new_v4()),
+            platform: Platform::ENS,
+            identity: domain.name.clone(),
+            uid: None,
+            created_at: ens_created_at,
+            display_name: Some(domain.name.clone()),
+            added_at: naive_now(),
+            avatar_url: None,
+            profile_url: None,
+            updated_at: naive_now(),
+            expired_at: ens_expired_at,
+            reverse: Some(false),
+        };
+        let contract = Contract {
+            uuid: Uuid::new_v4(),
+            category: ContractCategory::ENS,
+            address: ContractCategory::ENS.default_contract_address().unwrap(),
+            chain: Chain::Ethereum,
+            symbol: None,
+            updated_at: naive_now(),
+        };
+        let ownership: Hold = Hold {
+            uuid: Uuid::new_v4(),
+            transaction: creation_tx,
+            id: domain.name.clone(),
+            source: DataSource::TheGraph,
+            created_at: ens_created_at,
+            updated_at: naive_now(),
+            fetcher: DataFetcher::RelationService,
+            expired_at: ens_expired_at,
+        };
+
+        edges.push(EdgeWrapperEnum::new_hyper_edge(
+            HyperEdge {}.wrapper(&hv, &owner, HYPER_EDGE),
+        ));
+
+        let resolved_address = domain.resolved_address.map(|r| r.id);
+        match resolved_address.clone() {
+            None => {
+                // Resolve record not existed anymore. Save owner address.
+                trace!(
+                    ?target,
+                    "TheGraph: Resolve address not existed. Save owner address"
+                );
+                // hold record
+                let hd = ownership.wrapper(&owner, &ens_domain, HOLD_IDENTITY);
+                let hdc = ownership.wrapper(&owner, &contract, HOLD_CONTRACT);
+                edges.push(EdgeWrapperEnum::new_hold_identity(hd));
+                edges.push(EdgeWrapperEnum::new_hold_contract(hdc));
+                // Append up_next
+                if platform == Platform::ENS {
+                    next_targets.push(Target::Identity(
+                        Platform::Ethereum,
+                        domain.owner.id.clone(),
+                    ));
+                }
+            }
+            Some(address) => {
+                // Filter zero address (without last 4 digits)
+                if !address.starts_with("0x000000000000000000000000000000000000") {
+                    // Create resolve record
+                    debug!(?target, address, domain = domain.name, "TheGraph: Resolved");
+                    let resolve = Resolve {
+                        uuid: Uuid::new_v4(),
+                        source: DataSource::TheGraph,
+                        system: DomainNameSystem::ENS,
+                        name: domain.name.clone(),
+                        fetcher: DataFetcher::RelationService,
+                        updated_at: naive_now(),
+                    };
+
+                    let domain_owner = domain.owner.id.clone();
+
+                    if address == domain_owner {
+                        // ens_domain will be added to hyper_vertex IdentitiesGraph
+                        // only when resolvedAddress == owner
+                        edges.push(EdgeWrapperEnum::new_hyper_edge(HyperEdge {}.wrapper(
+                            &hv,
+                            &ens_domain,
+                            HYPER_EDGE,
+                        )));
+
+                        // hold record
+                        let hd = ownership.wrapper(&owner, &ens_domain, HOLD_IDENTITY);
+                        let hdc = ownership.wrapper(&owner, &contract, HOLD_CONTRACT);
+                        edges.push(EdgeWrapperEnum::new_hold_identity(hd));
+                        edges.push(EdgeWrapperEnum::new_hold_contract(hdc));
+
+                        // resolve record
+                        let rs = resolve.wrapper(&ens_domain, &owner, RESOLVE);
+                        let rsc = resolve.wrapper(&contract, &owner, RESOLVE_CONTRACT);
+                        edges.push(EdgeWrapperEnum::new_resolve(rs));
+                        edges.push(EdgeWrapperEnum::new_resolve_contract(rsc));
+
+                        // Append up_next
+                        if platform == Platform::ENS {
+                            next_targets
+                                .push(Target::Identity(Platform::Ethereum, domain_owner.clone()));
+                        }
+                    } else {
+                        debug!(
+                            ?target,
+                            address, domain_owner, "TheGraph: address != domain_owner"
+                        );
+                        // hold record
+                        let hd = ownership.wrapper(&owner, &ens_domain, HOLD_IDENTITY);
+                        let hdc = ownership.wrapper(&owner, &contract, HOLD_CONTRACT);
+                        edges.push(EdgeWrapperEnum::new_hold_identity(hd));
+                        edges.push(EdgeWrapperEnum::new_hold_contract(hdc));
+                        // Append up_next
+                        if platform == Platform::ENS {
+                            next_targets
+                                .push(Target::Identity(Platform::Ethereum, domain_owner.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    next_targets.dedup();
+    return Ok((next_targets, edges));
 }
 
 /// Focus on `ENS Domains` Saveing.

--- a/src/upstream/types/data_source.rs
+++ b/src/upstream/types/data_source.rs
@@ -184,7 +184,7 @@ pub enum DataSource {
     /// Twitter <-> Ethereum
     /// Manually added by Firefly.land team.
     /// Cannot be verified by third party, only trust the team.
-    #[strum(serialize = "hand_writing")]
+    #[strum(serialize = "manually_added")]
     #[serde(rename = "manually_added")]
     #[graphql(name = "manually_added")]
     ManuallyAdded,

--- a/src/upstream/types/platform.rs
+++ b/src/upstream/types/platform.rs
@@ -74,6 +74,12 @@ pub enum Platform {
     #[graphql(name = "facebook")]
     Facebook,
 
+    /// Instagram
+    #[strum(serialize = "instagram")]
+    #[serde(rename = "instagram")]
+    #[graphql(name = "instagram")]
+    Instagram,
+
     /// Mastodon maintained by Sujitech
     #[strum(serialize = "mstdnjp")]
     #[serde(rename = "mstdnjp")]
@@ -206,6 +212,7 @@ impl From<Platform> for DomainNameSystem {
             Platform::Crossbell => DomainNameSystem::SpaceId,
             Platform::ENS => DomainNameSystem::ENS,
             Platform::SNS => DomainNameSystem::SNS,
+            Platform::Genome => DomainNameSystem::Genome,
             _ => DomainNameSystem::Unknown,
         }
     }


### PR DESCRIPTION
https://github.com/NextDotID/relation_server/issues/146

add `batch_upsert` method for fetch jobs, `fetch_all` executes once upsert_graph after collecting all upstream data.
call tigergraph host:9002 `id_allocation`, asynchronously allocate HyperGraphIDs for data accumulation and data recovery

- [x] Refactor upstream `crossbell` batch_fetch
- [x] Refactor upstream `dotbit` batch_fetch
- [x] Refactor upstream `crossbell` batch_fetch
- [x] Refactor upstream `.bit` batch_fetch
- [x] Refactor upstream `ens_reverse` batch_fetch
- [x] Refactor upstream `farcaster` batch_fetch
- [x] Refactor upstream `genome` batch_fetch
- [x] Refactor upstream `keybase` batch_fetch
- [x] Refactor upstream `lens-v2` batch_fetch
- [x] Refactor upstream `proof_client` batch_fetch
- [x] Refactor upstream `space_id` batch_fetch
- [x] Refactor upstream `unstoppable_domains` batch_fetch
- [x] Refactor upstream `rss3` batch_fetch
- [x] Refactor upstream `solana` & `sns` batch_fetch
- [x] Refactor upstream `the_graph` & `ens` batch_fetch

Notice: 

- Temporarily cancel upstream: [`lens-v1`, `knn3`, `sybil_list`], `sybil_list` prefetch move to data_process as a scheduled asynchronous fetch.
- Upstream `Firefly` aggregation account and `opensea_account` connection 
temporarily cancel.